### PR TITLE
Introduce log reporter and queue mechanism for event publishing

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/AbstractMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/AbstractMetricReporter.java
@@ -68,6 +68,10 @@ public abstract class AbstractMetricReporter implements MetricReporter {
         } else if (!(metric instanceof CounterMetric)) {
             log.error("Timer Metric with the same name already exists. Please use a different name");
             return null;
+        } else if (metric.getSchema() != schema) {
+            log.error("Counter Metric with the same name but different schema already exists. Please use a different "
+                              + "name");
+            return null;
         }
         return (CounterMetric) metric;
     }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/Metric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/Metric.java
@@ -28,4 +28,11 @@ public interface Metric {
      * @return Name of the metric
      */
     public String getName();
+
+    /**
+     * Method to get schema name
+     *
+     * @return Schema name of this Metric
+     */
+    public MetricSchema getSchema();
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
@@ -46,7 +46,7 @@ public class MetricReporterFactory {
             throws MetricCreationException {
         if (reporterRegistry.get(Constants.DEFAULT_REPORTER) == null) {
             synchronized (this) {
-                if (reporterRegistry.get("default") == null) {
+                if (reporterRegistry.get(Constants.DEFAULT_REPORTER) == null) {
                         MetricReporter reporterInstance = new ChoreoAnalyticsMetricReporter(properties);
                         reporterRegistry.put("default", reporterInstance);
                         return reporterInstance;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
@@ -25,6 +25,7 @@ import org.wso2.am.analytics.publisher.util.Constants;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -34,44 +35,59 @@ import java.util.Map;
  */
 public class MetricReporterFactory {
     private static final Logger log = Logger.getLogger(MetricReporterFactory.class);
-    private static volatile MetricReporter reporterInstance;
     private static final MetricReporterFactory instance = new MetricReporterFactory();
+    private static Map<String, MetricReporter> reporterRegistry = new HashMap<>();
 
     private MetricReporterFactory() {
         //private constructor
     }
+
+    public MetricReporter createMetricReporter(Map<String, String> properties)
+            throws MetricCreationException {
+        if (reporterRegistry.get(Constants.DEFAULT_REPORTER) == null) {
+            synchronized (this) {
+                if (reporterRegistry.get("default") == null) {
+                        MetricReporter reporterInstance = new ChoreoAnalyticsMetricReporter(properties);
+                        reporterRegistry.put("default", reporterInstance);
+                        return reporterInstance;
+                }
+            }
+        }
+        MetricReporter reporterInstance = reporterRegistry.get("default");
+        log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
+                         " is already created. Hence returning same instance");
+        return reporterInstance;
+    }
     public MetricReporter createMetricReporter(String fullyQualifiedClassName, Map<String, String> properties)
             throws MetricCreationException {
-        if (reporterInstance == null) {
+        if (reporterRegistry.get(fullyQualifiedClassName) == null) {
             synchronized (this) {
-                if (reporterInstance == null) {
-                    if (fullyQualifiedClassName == null || fullyQualifiedClassName.isEmpty() ||
-                            Constants.CHOREO_ANALYTICS_REPORTER_FQCN.equals(fullyQualifiedClassName)) {
-                        reporterInstance = new ChoreoAnalyticsMetricReporter(properties);
-                        return reporterInstance;
-                    } else {
+                if (reporterRegistry.get(fullyQualifiedClassName) == null) {
+                    if (fullyQualifiedClassName != null && !fullyQualifiedClassName.isEmpty()) {
                         try {
                             Class<MetricReporter> clazz =
                                     (Class<MetricReporter>) Class.forName(fullyQualifiedClassName);
                             Constructor<MetricReporter> constructor =
                                     clazz.getConstructor(Map.class);
-                            reporterInstance = constructor.newInstance(properties);
+                            MetricReporter reporterInstance = constructor.newInstance(properties);
+                            reporterRegistry.put(fullyQualifiedClassName, reporterInstance);
                             return reporterInstance;
                         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException
                                 | NoSuchMethodException | InvocationTargetException e) {
-                            throw new MetricCreationException("Provided class name " + fullyQualifiedClassName +
-                                                                      " is not supported.", e);
+                            throw new MetricCreationException("Error occurred while creating a Metric Reporter of type"
+                                                                      + " " + fullyQualifiedClassName, e);
                         }
+                    } else {
+                        throw new MetricCreationException("Provided class name is either empty or null. Hence cannot "
+                                                                  + "create the Reporter.");
                     }
-                } else {
-                    return reporterInstance;
                 }
             }
-        } else {
-            log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
-                             " is already created. Hence returning same instance");
-            return reporterInstance;
         }
+        MetricReporter reporterInstance = reporterRegistry.get(fullyQualifiedClassName);
+        log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
+                         " is already created. Hence returning same instance");
+        return reporterInstance;
     }
 
     public static MetricReporterFactory getInstance() {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
@@ -23,6 +23,8 @@ import org.wso2.am.analytics.publisher.exception.MetricCreationException;
 import org.wso2.am.analytics.publisher.reporter.choreo.ChoreoAnalyticsMetricReporter;
 import org.wso2.am.analytics.publisher.util.Constants;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 /**
@@ -48,8 +50,18 @@ public class MetricReporterFactory {
                         reporterInstance = new ChoreoAnalyticsMetricReporter(properties);
                         return reporterInstance;
                     } else {
-                        throw new MetricCreationException("Provided class name " + fullyQualifiedClassName +
-                                                                  " is not supported.");
+                        try {
+                            Class<MetricReporter> clazz =
+                                    (Class<MetricReporter>) Class.forName(fullyQualifiedClassName);
+                            Constructor<MetricReporter> constructor =
+                                    clazz.getConstructor(Map.class);
+                            reporterInstance = constructor.newInstance(properties);
+                            return reporterInstance;
+                        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException
+                                | NoSuchMethodException | InvocationTargetException e) {
+                            throw new MetricCreationException("Provided class name " + fullyQualifiedClassName +
+                                                                      " is not supported.", e);
+                        }
                     }
                 } else {
                     return reporterInstance;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/ChoreoAnalyticsThreadFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/ChoreoAnalyticsThreadFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.choreo;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Custom Thread Factory for Analytics publisher impl
+ */
+public class ChoreoAnalyticsThreadFactory implements ThreadFactory {
+    private static final AtomicInteger poolNumber = new AtomicInteger(1);
+    final ThreadGroup group;
+    final AtomicInteger threadNumber = new AtomicInteger(1);
+    final String namePrefix;
+
+    public ChoreoAnalyticsThreadFactory(String threadPoolExecutorName) {
+        SecurityManager s = System.getSecurityManager();
+        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        namePrefix = "Choreo-Analytics-" + threadPoolExecutorName + "-pool-" + poolNumber.getAndIncrement() +
+                "-thread-";
+    }
+
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
+        if (t.isDaemon()) {
+            t.setDaemon(false);
+        }
+        if (t.getPriority() != Thread.NORM_PRIORITY) {
+            t.setPriority(Thread.NORM_PRIORITY);
+        }
+        return t;
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/EventQueue.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.choreo;
+
+import org.apache.log4j.Logger;
+import org.wso2.am.analytics.publisher.client.EventHubClient;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Bounded concurrent queue wrapping {@link java.util.concurrent.ArrayBlockingQueue}
+ */
+public class EventQueue {
+
+    private static final Logger log = Logger.getLogger(EventQueue.class);
+    private BlockingQueue<String> eventQueue;
+    private ExecutorService executorService;
+    private EventHubClient client;
+
+    public EventQueue(int queueSize, int workerThreadCount, EventHubClient client) {
+        this.client = client;
+        // Note : Using a fixed worker thread pool and a bounded queue to control the load on the server
+        executorService = Executors.newFixedThreadPool(workerThreadCount,
+                                                       new ChoreoAnalyticsThreadFactory("Queue-Worker"));
+        eventQueue = new ArrayBlockingQueue<>(queueSize);
+    }
+
+    public void put(String event) {
+        try {
+            eventQueue.put(event);
+            executorService.submit(new QueueWorker(eventQueue, client, executorService));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (RejectedExecutionException e) {
+            log.warn("Task submission failed. Task queue might be full", e);
+        }
+
+    }
+
+    public boolean isQueueEmpty() {
+        return eventQueue.peek() == null;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        executorService.shutdown();
+        super.finalize();
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/QueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/QueueWorker.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.choreo;
+
+import org.apache.log4j.Logger;
+import org.wso2.am.analytics.publisher.client.EventHubClient;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Will removes the events from queues and send then to the endpoints.
+ */
+public class QueueWorker implements Runnable {
+
+    private static final Logger log = Logger.getLogger(QueueWorker.class);
+    private BlockingQueue<String> eventQueue;
+    private ExecutorService executorService;
+    private EventHubClient client;
+
+    public QueueWorker(BlockingQueue<String> queue, EventHubClient client, ExecutorService executorService) {
+        this.client = client;
+        this.eventQueue = queue;
+        this.executorService = executorService;
+    }
+
+    public void run() {
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug(eventQueue.size() + " messages in queue before " +
+                                  Thread.currentThread().getName().replaceAll("[\r\n]", "")
+                                  + " worker has polled queue");
+            }
+            ThreadPoolExecutor threadPoolExecutor = ((ThreadPoolExecutor) executorService);
+            do {
+                String event = eventQueue.poll();
+                if (event != null) {
+                    client.sendEvent(event);
+                } else {
+                    //if we are done with consuming blocking queue flush the EventHub Client batch
+                    client.flushEvents();
+                }
+            } while (threadPoolExecutor.getActiveCount() <= 3 && eventQueue.size() != 0);
+            if (log.isDebugEnabled()) {
+                log.debug(eventQueue.size() + " messages in queue after " +
+                                  Thread.currentThread().getName().replaceAll("[\r\n]", "")
+                                  + " worker has finished work");
+            }
+        } catch (Throwable e) {
+            log.error("Error in passing events to Event Hub client. Events dropped", e);
+        }
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/QueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/choreo/QueueWorker.java
@@ -55,8 +55,15 @@ public class QueueWorker implements Runnable {
                 } else {
                     //if we are done with consuming blocking queue flush the EventHub Client batch
                     client.flushEvents();
+                    break;
                 }
-            } while (threadPoolExecutor.getActiveCount() <= 3 && eventQueue.size() != 0);
+                if (eventQueue.size() == 0) {
+                    //if we are done with consuming blocking queue flush the EventHub Client batch
+                    client.flushEvents();
+                    break;
+                }
+            } while (threadPoolExecutor.getActiveCount() == 1 && eventQueue.size() != 0);
+            //while condition to handle possible task rejections
             if (log.isDebugEnabled()) {
                 log.debug(eventQueue.size() + " messages in queue after " +
                                   Thread.currentThread().getName().replaceAll("[\r\n]", "")

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogCounterMetric.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.reporter.log;
+
+import org.apache.log4j.Logger;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+
+import java.util.Map;
+
+public class LogCounterMetric implements CounterMetric {
+    private static final Logger log = Logger.getLogger(LogCounterMetric.class);
+    private final String name;
+
+    protected LogCounterMetric(String name) {
+        this.name = name;
+    }
+
+    @Override public int incrementCount(Map<String, String> properties) throws MetricReportingException {
+        log.info("Metric Name: " + name + " Metric Value: " + properties.toString());
+        return 0;
+    }
+
+    @Override public String getName() {
+        return name;
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogCounterMetric.java
@@ -36,17 +36,20 @@ public class LogCounterMetric implements CounterMetric {
         this.name = name;
     }
 
-    @Override public int incrementCount(Map<String, String> properties) throws MetricReportingException {
+    @Override
+    public int incrementCount(Map<String, String> properties) throws MetricReportingException {
         log.info("Metric Name: " + name.replaceAll("[\r\n]", "") + " Metric Value: "
                          + properties.toString().replaceAll("[\r\n]", ""));
         return 0;
     }
 
-    @Override public String getName() {
+    @Override
+    public String getName() {
         return name;
     }
 
-    @Override public MetricSchema getSchema() {
+    @Override
+    public MetricSchema getSchema() {
         return null;
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogCounterMetric.java
@@ -21,9 +21,13 @@ package org.wso2.am.analytics.publisher.reporter.log;
 import org.apache.log4j.Logger;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
 
 import java.util.Map;
 
+/**
+ * Log counter metric class. Intended for testing only.
+ */
 public class LogCounterMetric implements CounterMetric {
     private static final Logger log = Logger.getLogger(LogCounterMetric.class);
     private final String name;
@@ -33,11 +37,16 @@ public class LogCounterMetric implements CounterMetric {
     }
 
     @Override public int incrementCount(Map<String, String> properties) throws MetricReportingException {
-        log.info("Metric Name: " + name + " Metric Value: " + properties.toString());
+        log.info("Metric Name: " + name.replaceAll("[\r\n]", "") + " Metric Value: "
+                         + properties.toString().replaceAll("[\r\n]", ""));
         return 0;
     }
 
     @Override public String getName() {
         return name;
+    }
+
+    @Override public MetricSchema getSchema() {
+        return null;
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogMetricReporter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.reporter.log;
+
+import org.wso2.am.analytics.publisher.exception.MetricCreationException;
+import org.wso2.am.analytics.publisher.reporter.AbstractMetricReporter;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.am.analytics.publisher.reporter.TimerMetric;
+
+import java.util.Map;
+
+public class LogMetricReporter extends AbstractMetricReporter {
+
+    public LogMetricReporter(Map<String, String> properties) throws MetricCreationException {
+        super(properties);
+    }
+
+    @Override protected void validateConfigProperties(Map<String, String> properties) throws MetricCreationException {
+        //nothing to validate
+    }
+
+    @Override protected CounterMetric createCounter(String name, MetricSchema schema) {
+        return new LogCounterMetric(name);
+    }
+
+    @Override protected TimerMetric createTimer(String name) {
+        return null;
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/log/LogMetricReporter.java
@@ -26,6 +26,9 @@ import org.wso2.am.analytics.publisher.reporter.TimerMetric;
 
 import java.util.Map;
 
+/**
+ * Log Metric Reporter class. Intended for testing only.
+ */
 public class LogMetricReporter extends AbstractMetricReporter {
 
     public LogMetricReporter(Map<String, String> properties) throws MetricCreationException {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -59,4 +59,5 @@ public class Constants {
     public static final String CONSUMER_KEY = "consumer.key";
     public static final String CONSUMER_SECRET = "consumer.secret";
     public static final String SAS_TOKEN = "sas.token";
+    public static final String DEFAULT_REPORTER = "default";
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher;
+
+import org.apache.log4j.Logger;
+import org.testng.annotations.Test;
+import org.wso2.am.analytics.publisher.exception.MetricCreationException;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.MetricReporter;
+import org.wso2.am.analytics.publisher.reporter.MetricReporterFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LogMetricReporterTestCase {
+    private static final Logger log = Logger.getLogger(MetricReporterTestCase.class);
+
+
+    @Test
+    public void testMetricReporterCreationWithoutConfigs() throws MetricCreationException, MetricReportingException {
+        MetricReporter metricReporter = MetricReporterFactory.getInstance().createMetricReporter(
+                "org.wso2.am.analytics.publisher.reporter.log.LogMetricReporter", null);
+        CounterMetric metric = metricReporter.createCounterMetric("testCounter", null);
+
+        Map<String, String> event = new HashMap<>();
+        event.put("attribute1", "value1");
+        event.put("attribute2", "value2");
+        event.put("attribute3", "value3");
+        event.put("attribute4", "value4");
+        metric.incrementCount(event);
+    }
+}

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
@@ -44,6 +44,7 @@ public class LogMetricReporterTestCase {
         event.put("attribute2", "value2");
         event.put("attribute3", "value3");
         event.put("attribute4", "value4");
+
         metric.incrementCount(event);
     }
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
@@ -30,11 +30,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class LogMetricReporterTestCase {
-    private static final Logger log = Logger.getLogger(MetricReporterTestCase.class);
+    private static final Logger log = Logger.getLogger(LogMetricReporterTestCase.class);
 
 
     @Test
     public void testMetricReporterCreationWithoutConfigs() throws MetricCreationException, MetricReportingException {
+        log.info("Running log metric test case");
         MetricReporter metricReporter = MetricReporterFactory.getInstance().createMetricReporter(
                 "org.wso2.am.analytics.publisher.reporter.log.LogMetricReporter", null);
         CounterMetric metric = metricReporter.createCounterMetric("testCounter", null);

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+    <!--api-->
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.reporter.choreo.EventQueue"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,28 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${maven.findbugsplugin.version}</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
+                    <!--Exclude sources-->
+                    <excludeFilterFile>${maven.findbugsplugin.exclude.file}</excludeFilterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>analyze-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <properties>
@@ -132,6 +154,7 @@
         <junit.version>4.13.1</junit.version>
         <testng.version>6.10</testng.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
+        <maven.findbugsplugin.exclude.file>findbugs-exclude.xml</maven.findbugsplugin.exclude.file>
         <carbon.feature.plugin.version>3.1.4</carbon.feature.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
## Purpose
- To address https://github.com/wso2/apim-analytics-publisher/issues/17
- To provide an easy way to test intrumentation

## Goals
- Adds event queuing capability
- Adds a Log Metric Reporter which will output metric events to the log

## Approach
- Queuing is implemented using a bounded ArrayBlockingQueue. Producers will drop events if the queue is full. Consumers will keep on consuming the queue till queue becomes empty. EventHub client batching is also enabled
- Each metric attribute map will be converted to string and logged

## Documentation
To use log metric reporter
```
MetricReporter metricReporter = MetricReporterFactory.getInstance().createMetricReporter(
                "org.wso2.am.analytics.publisher.reporter.log.LogMetricReporter", null);
        CounterMetric metric = metricReporter.createCounterMetric("testCounter", null);

        Map<String, String> event = new HashMap<>();
        event.put("attribute1", "value1");
        event.put("attribute2", "value2");
        event.put("attribute3", "value3");
        event.put("attribute4", "value4");

        metric.incrementCount(event);
```


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
