### PR TITLE
Publisher error handling feature

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -16,7 +16,8 @@
 ~ specific language governing permissions and limitations
 ~ under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.am.analytics.publisher</groupId>
         <artifactId>apim-analytics-publisher-component</artifactId>
@@ -64,8 +65,13 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-slf4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.3.9.RELEASE</version>
+        </dependency>
     </dependencies>
-    
+
     <build>
         <resources>
             <resource>

--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -65,11 +65,6 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-slf4j</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-core</artifactId>
-            <version>3.3.9.RELEASE</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthClient.java
@@ -47,14 +47,13 @@ public class AuthClient {
             return dto.getToken();
         } catch (FeignException.Unauthorized e) {
             throw new ConnectionUnrecoverableException(
-                    "Invalid user token. Analytics data publishing will be disabled. Please update apim.analytics"
+                    "Invalid/expired user token. Please update apim.analytics"
                             + ".auth_token in configuration and restart the instance", e);
         } catch (RetryableException e) {
             throw new ConnectionRecoverableException("Provided authentication endpoint " + authEndpoint + " is not "
                                                              + "reachable.");
         } catch (IllegalArgumentException e) {
-            throw new ConnectionUnrecoverableException("Invalid apim.analytics configurations provided. Analytics "
-                                                               + "data publishing will be disabled. Please update "
+            throw new ConnectionUnrecoverableException("Invalid apim.analytics configurations provided. Please update "
                                                                + "configurations and restart the instance.");
         } catch (Exception e) {
             //we will retry for any other exception

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthClient.java
@@ -55,6 +55,8 @@ public class AuthClient {
         } catch (IllegalArgumentException e) {
             throw new ConnectionUnrecoverableException("Invalid apim.analytics configurations provided. Please update "
                                                                + "configurations and restart the instance.");
+        } catch (FeignException.Forbidden e) {
+            throw new ConnectionRecoverableException("Publisher has been temporarily revoked.");
         } catch (Exception e) {
             //we will retry for any other exception
             throw new ConnectionRecoverableException("Exception " + e.getClass() + " occurred.");

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/ClientStatus.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/ClientStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.client;
+
+/**
+ * Enum to represent the status of Eventhub publisher
+ */
+public enum ClientStatus {
+    CONNECTED,
+    NOT_CONNECTED,
+    RETRYING
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
@@ -86,6 +86,9 @@ public class EventHubClient {
     private void createProducerWithRetry(String authEndpoint, String authToken,
                                          AmqpRetryOptions retryOptions, boolean createBatch) {
         try {
+            if (producer != null) {
+                producer.close();
+            }
             producer = EventHubProducerClientFactory.create(authEndpoint, authToken, retryOptions);
             try {
                 if (createBatch) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
@@ -17,14 +17,23 @@
  */
 package org.wso2.am.analytics.publisher.client;
 
+import com.azure.core.amqp.AmqpRetryOptions;
+import com.azure.core.amqp.exception.AmqpErrorCondition;
+import com.azure.core.amqp.exception.AmqpException;
 import com.azure.messaging.eventhubs.EventData;
 import com.azure.messaging.eventhubs.EventDataBatch;
 import com.azure.messaging.eventhubs.EventHubProducerClient;
 import org.apache.log4j.Logger;
 import org.wso2.am.analytics.publisher.exception.ConnectionRecoverableException;
 import org.wso2.am.analytics.publisher.exception.ConnectionUnrecoverableException;
+import org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsThreadFactory;
+import org.wso2.am.analytics.publisher.util.BackoffRetryCounter;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -34,15 +43,58 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class EventHubClient {
     private static final Logger log = Logger.getLogger(EventHubClient.class);
+    private final String authEndpoint;
+    private final String authToken;
+    private final ReadWriteLock readWriteLock;
+    private final BackoffRetryCounter producerRetryCounter;
+    private final BackoffRetryCounter eventBatchRetryCounter;
+    private final Object threadBarrier = new Object();
+    private final AmqpRetryOptions retryOptions;
     private EventHubProducerClient producer;
     private EventDataBatch batch;
-    private ReadWriteLock readWriteLock;
     private Semaphore sendSemaphore;
     private ClientStatus clientStatus;
+    private ScheduledExecutorService scheduledExecutorService;
 
-    public EventHubClient(String authEndpoint, String authToken) {
+    public EventHubClient(String authEndpoint, String authToken, AmqpRetryOptions retryOptions) {
+        readWriteLock = new ReentrantReadWriteLock(true);
+        sendSemaphore = new Semaphore(1);
+        scheduledExecutorService = Executors.newScheduledThreadPool(2, new DefaultAnalyticsThreadFactory(
+                "Reconnection-Service"));
+        producerRetryCounter = new BackoffRetryCounter();
+        eventBatchRetryCounter = new BackoffRetryCounter();
+        this.authEndpoint = authEndpoint;
+        this.authToken = authToken;
+        this.retryOptions = retryOptions;
+        createProducerWithRetry(authEndpoint, authToken, retryOptions, true);
+    }
+
+    private void retryWithBackoff(String authEndpoint, String authToken,
+                                  AmqpRetryOptions retryOptions, boolean createBatch) {
+        scheduledExecutorService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                createProducerWithRetry(authEndpoint, authToken, retryOptions, createBatch);
+            }
+        }, producerRetryCounter.getTimeIntervalMillis(), TimeUnit.MILLISECONDS);
+        producerRetryCounter.increment();
+    }
+
+    private void createProducerWithRetry(String authEndpoint, String authToken,
+                                         AmqpRetryOptions retryOptions, boolean createBatch) {
         try {
-            producer = EventHubProducerClientFactory.create(authEndpoint, authToken);
+            producer = EventHubProducerClientFactory.create(authEndpoint, authToken, retryOptions);
+            try {
+                if (createBatch) {
+                    batch = producer.createBatch();
+                }
+            } catch (IllegalStateException e) {
+                throw new ConnectionRecoverableException("Event batch creation failed. " + e.getMessage()
+                        .replaceAll("[\r\n]", ""));
+            }
+            clientStatus = ClientStatus.CONNECTED;
+            producerRetryCounter.reset();
+            threadBarrier.notifyAll();
         } catch (ConnectionRecoverableException e) {
             clientStatus = ClientStatus.RETRYING;
             log.error("Recoverable error occurred when creating Eventhub Client. Retry attempts will be made. Reason :"
@@ -50,6 +102,7 @@ public class EventHubClient {
             log.debug("Recoverable error occurred when creating Eventhub Client using following attributes. Auth "
                               + "endpoint: " + authEndpoint.replaceAll("[\r\n]", "") + ". Retry attempts will be made. "
                               + "Reason : " + e.getMessage().replaceAll("[\r\n]", ""), e);
+            retryWithBackoff(authEndpoint, authToken, retryOptions, createBatch);
         } catch (ConnectionUnrecoverableException e) {
             clientStatus = ClientStatus.NOT_CONNECTED;
             log.error("Unrecoverable error occurred when creating Eventhub Client. Analytics event publishing will be"
@@ -59,70 +112,137 @@ public class EventHubClient {
                               + "endpoint: " + authEndpoint.replaceAll("[\r\n]", "") + ". Analytics event publishing "
                               + "will be disabled until issue is rectified. Reason: "
                               + e.getMessage().replaceAll("[\r\n]", ""), e);
-            return;
         }
-        clientStatus = ClientStatus.CONNECTED;
-        batch = producer.createBatch();
-        readWriteLock = new ReentrantReadWriteLock();
-        sendSemaphore = new Semaphore(1);
     }
 
     public void sendEvent(String event) {
-        if (producer == null) {
-            log.error("EventHubClient has failed. Hence ignoring.");
-            return;
-        }
-        EventData eventData = new EventData(event);
-        readWriteLock.readLock().lock();
-        try {
-            boolean isAdded = batch.tryAdd(eventData);
-            if (!isAdded) {
-                try {
-                    sendSemaphore.acquire();
-                    isAdded = batch.tryAdd(eventData);
-                    if (!isAdded) {
-                        int size = batch.getCount();
-                        producer.send(batch);
-                        batch = producer.createBatch();
+        if (clientStatus == ClientStatus.CONNECTED) {
+            EventData eventData = new EventData(event);
+            readWriteLock.readLock().lock();
+            try {
+                boolean isAdded = batch.tryAdd(eventData);
+                if (!isAdded) {
+                    try {
+                        readWriteLock.readLock().unlock();
+                        readWriteLock.writeLock().lock();
                         isAdded = batch.tryAdd(eventData);
-                        log.debug("Published " + size + " events to Analytics cluster.");
+                        if (!isAdded) {
+                            int size = batch.getCount();
+                            producer.send(batch);
+                            batch = createBatchWithRetry();
+                            isAdded = batch.tryAdd(eventData);
+                            log.debug("Published " + size + " events to Analytics cluster.");
+                        }
+                    } catch (Exception e) {
+                        if (e.getCause() instanceof TimeoutException) {
+                            log.error("Timeout occurred after retrying " + retryOptions.getMaxRetries() + " "
+                                              + "times with an timeout of " + retryOptions.getTryTimeout() + " "
+                                              + "seconds while trying to publish EventDataBatch. Next retry cycle "
+                                              + "will begin shortly.");
+                            readWriteLock.writeLock().unlock();
+                            sendEvent(event);
+                        } else if (e instanceof AmqpException && isAuthenticationFailure((AmqpException) e)) {
+                            //if authentication error try to reinitialize publisher. Retrying will deal with any
+                            // network or revocation failures.
+                            log.error("Authentication issue happened. Producer client will be re-initialized "
+                                              + "retaining the EventDataBatch");
+                            this.clientStatus = ClientStatus.RETRYING;
+                            createProducerWithRetry(authEndpoint, authToken, retryOptions, false);
+                            readWriteLock.writeLock().unlock();
+                            sendEvent(event);
+                        } else if (e instanceof AmqpException && ((AmqpException) e).getErrorCondition()
+                                == AmqpErrorCondition.RESOURCE_LIMIT_EXCEEDED) {
+                            //If resource limit is exceeded we will retry after a constant delay
+                            log.error("Resource limit exceeded when publishing EventDataBatch. Operation will be "
+                                              + "retried after constant delay");
+                            try {
+                                Thread.sleep(1000 * 60);
+                            } catch (InterruptedException interruptedException) {
+                                Thread.currentThread().interrupt();
+                            }
+                            readWriteLock.writeLock().unlock();
+                            sendEvent(event);
+                        } else {
+                            //For any other exception
+                            log.error("Unknown error occurred while publishing EventDataBatch. Producer client will "
+                                              + "be re-initialized. Events may be lost in the process.");
+                            this.clientStatus = ClientStatus.RETRYING;
+                            readWriteLock.writeLock().unlock();
+                            createProducerWithRetry(authEndpoint, authToken, retryOptions, true);
+                        }
+                    } finally {
+                        try {
+                            readWriteLock.writeLock().unlock();
+                        } catch (IllegalMonitorStateException e) {
+                            //ignore
+                        }
                     }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    sendSemaphore.release();
+                }
+                if (isAdded) {
+                    log.debug("Adding event: " + event.replaceAll("[\r\n]", ""));
+                } else {
+                    log.debug("Failed to add event: " + event.replaceAll("[\r\n]", ""));
+                }
+            } finally {
+                try {
+                    readWriteLock.readLock().unlock();
+                } catch (IllegalMonitorStateException e) {
+                    //ignore
                 }
             }
-
-            if (isAdded) {
-                log.debug("Adding event: " + event.replaceAll("[\r\n]", ""));
-            } else {
-                log.debug("Failed to add event: " + event.replaceAll("[\r\n]", ""));
+        } else {
+            try {
+                log.debug(Thread.currentThread().getName().replaceAll("[\r\n]", "") + " will be parked as EventHub "
+                                  + "Client is inactive.");
+                threadBarrier.wait();
+                log.debug(Thread.currentThread().getName().replaceAll("[\r\n]", "") + " will be resumes as EventHub "
+                                  + "Client is active.");
+                sendEvent(event);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
-        } finally {
-            readWriteLock.readLock().unlock();
+        }
+    }
+
+    private boolean isAuthenticationFailure(AmqpException exception) {
+        AmqpErrorCondition condition = exception.getErrorCondition();
+        return (condition == AmqpErrorCondition.UNAUTHORIZED_ACCESS ||
+                condition == AmqpErrorCondition.PUBLISHER_REVOKED_ERROR);
+    }
+
+    private EventDataBatch createBatchWithRetry() {
+        try {
+            EventDataBatch batch = producer.createBatch();
+            eventBatchRetryCounter.reset();
+            return batch;
+        } catch (IllegalStateException e) {
+            log.error("Error in creating EventDataBatch. Will be retried in "
+                              + eventBatchRetryCounter.getTimeInterval().replaceAll("[\r\n]", ""));
+            try {
+                Thread.sleep(eventBatchRetryCounter.getTimeIntervalMillis());
+            } catch (InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            eventBatchRetryCounter.increment();
+            return createBatchWithRetry();
         }
     }
 
     public void flushEvents() {
-        if (producer == null) {
-            log.error("EventHubClient has failed. Hence ignoring.");
-            return;
-        }
         try {
-            sendSemaphore.acquire();
+            readWriteLock.writeLock().lock();
             int size = batch.getCount();
             producer.send(batch);
             batch = producer.createBatch();
             log.debug("Flushed " + size + " events to Analytics cluster.");
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
         } finally {
-            sendSemaphore.release();
+            readWriteLock.writeLock().unlock();
         }
     }
 
     public ClientStatus getStatus() {
         return clientStatus;
     }
+
+
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubProducerClientFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubProducerClientFactory.java
@@ -18,6 +18,7 @@
 
 package org.wso2.am.analytics.publisher.client;
 
+import com.azure.core.amqp.AmqpRetryOptions;
 import com.azure.core.credential.TokenCredential;
 import com.azure.messaging.eventhubs.EventHubClientBuilder;
 import com.azure.messaging.eventhubs.EventHubProducerClient;
@@ -35,7 +36,8 @@ import java.net.URLDecoder;
 public class EventHubProducerClientFactory {
     private static final Logger log = Logger.getLogger(EventHubClient.class);
 
-    public static EventHubProducerClient create(String authEndpoint, String authToken)
+    public static EventHubProducerClient create(String authEndpoint, String authToken,
+                                                AmqpRetryOptions retryOptions)
             throws ConnectionRecoverableException, ConnectionUnrecoverableException {
         TokenCredential tokenCredential = new WSO2TokenCredential(authEndpoint, authToken);
         String tempSASToken = null;
@@ -47,6 +49,7 @@ public class EventHubProducerClientFactory {
         String eventhubName = getEventHubName(resourceURI);
         return new EventHubClientBuilder()
                 .credential(fullyQualifiedNamespace, eventhubName, tokenCredential)
+                .retry(retryOptions)
                 .buildProducerClient();
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubProducerClientFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubProducerClientFactory.java
@@ -23,7 +23,8 @@ import com.azure.messaging.eventhubs.EventHubClientBuilder;
 import com.azure.messaging.eventhubs.EventHubProducerClient;
 import org.apache.log4j.Logger;
 import org.wso2.am.analytics.publisher.auth.AuthClient;
-import org.wso2.am.analytics.publisher.exception.AuthenticationException;
+import org.wso2.am.analytics.publisher.exception.ConnectionRecoverableException;
+import org.wso2.am.analytics.publisher.exception.ConnectionUnrecoverableException;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -34,16 +35,12 @@ import java.net.URLDecoder;
 public class EventHubProducerClientFactory {
     private static final Logger log = Logger.getLogger(EventHubClient.class);
 
-    public static EventHubProducerClient create(String authEndpoint, String authToken) {
+    public static EventHubProducerClient create(String authEndpoint, String authToken)
+            throws ConnectionRecoverableException, ConnectionUnrecoverableException {
         TokenCredential tokenCredential = new WSO2TokenCredential(authEndpoint, authToken);
-        String tempSASToken;
-        try {
-            // generate SAS token to get eventhub meta data
-            tempSASToken = getSASToken(authEndpoint, authToken);
-        } catch (AuthenticationException e) {
-            log.error("SAS token generation failed.", e);
-            return null;
-        }
+        String tempSASToken = null;
+        // generate SAS token to get eventhub meta data
+        tempSASToken = getSASToken(authEndpoint, authToken);
 
         String resourceURI = getResourceURI(tempSASToken);
         String fullyQualifiedNamespace = getNamespace(resourceURI);
@@ -53,7 +50,8 @@ public class EventHubProducerClientFactory {
                 .buildProducerClient();
     }
 
-    private static String getSASToken(String authEndpoint, String authToken) throws AuthenticationException {
+    private static String getSASToken(String authEndpoint, String authToken) throws ConnectionRecoverableException,
+                                                                                    ConnectionUnrecoverableException {
         return AuthClient.getSASToken(authEndpoint, authToken);
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/WSO2TokenCredential.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/WSO2TokenCredential.java
@@ -68,9 +68,11 @@ class WSO2TokenCredential implements TokenCredential {
             backoffRetryCounter.increment();
             return getToken(tokenRequestContext);
         } catch (ConnectionUnrecoverableException e) {
+            //Do not pass the exception. Publishing threads will encounter authentication issue and then try to
+            // reinitialize publisher.
             log.error("Error occurred when retrieving SAS token.", e);
             backoffRetryCounter.reset();
-            throw new RuntimeException("Error occurred when retrieving SAS token.");
+            return null;
         }
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/WSO2TokenCredential.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/WSO2TokenCredential.java
@@ -23,7 +23,8 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 import org.apache.log4j.Logger;
 import org.wso2.am.analytics.publisher.auth.AuthClient;
-import org.wso2.am.analytics.publisher.exception.AuthenticationException;
+import org.wso2.am.analytics.publisher.exception.ConnectionRecoverableException;
+import org.wso2.am.analytics.publisher.exception.ConnectionUnrecoverableException;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -52,9 +53,12 @@ class WSO2TokenCredential implements TokenCredential {
             // Using lower duration than actual.
             OffsetDateTime time = OffsetDateTime.now(ZoneOffset.UTC).plus(Duration.ofHours(20));
             return Mono.fromCallable(() -> new AccessToken(sasToken, time));
-        } catch (AuthenticationException e) {
+        } catch (ConnectionRecoverableException e) {
+            log.error("Error occurred when retrieving SAS token. Connection will be retried", e);
+            throw new RuntimeException("Error occurred when retrieving SAS token. Connection will be retried");
+        } catch (ConnectionUnrecoverableException e) {
             log.error("Error occurred when retrieving SAS token.", e);
-            throw new RuntimeException("Error occurred when retrieving SAS token.", e);
+            throw new RuntimeException("Error occurred when retrieving SAS token.");
         }
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/ConnectionRecoverableException.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/ConnectionRecoverableException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.exception;
+
+/**
+ * Exception to represent any recoverable errors event publishing client encounter
+ */
+public class ConnectionRecoverableException extends Exception {
+    public ConnectionRecoverableException(String msg) {
+        super(msg);
+    }
+
+    public ConnectionRecoverableException(String msg, Throwable e) {
+        super(msg, e);
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/ConnectionUnrecoverableException.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/ConnectionUnrecoverableException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.exception;
+
+/**
+ * Exception to represent any unrecoverable errors event publishing client encounter
+ */
+public class ConnectionUnrecoverableException extends Exception {
+    public ConnectionUnrecoverableException(String msg) {
+        super(msg);
+    }
+
+    public ConnectionUnrecoverableException(String msg, Throwable e) {
+        super(msg, e);
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
@@ -48,12 +48,12 @@ public class MetricReporterFactory {
             synchronized (this) {
                 if (reporterRegistry.get(Constants.DEFAULT_REPORTER) == null) {
                         MetricReporter reporterInstance = new DefaultAnalyticsMetricReporter(properties);
-                        reporterRegistry.put("default", reporterInstance);
+                        reporterRegistry.put(Constants.DEFAULT_REPORTER, reporterInstance);
                         return reporterInstance;
                 }
             }
         }
-        MetricReporter reporterInstance = reporterRegistry.get("default");
+        MetricReporter reporterInstance = reporterRegistry.get(Constants.DEFAULT_REPORTER);
         log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
                          " is already created. Hence returning same instance");
         return reporterInstance;
@@ -88,6 +88,13 @@ public class MetricReporterFactory {
         log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
                          " is already created. Hence returning same instance");
         return reporterInstance;
+    }
+
+    /**
+     * Reset the MetricReporterFactory registry. Only intended to be used in testing
+     */
+    public void reset() {
+        reporterRegistry.clear();
     }
 
     public static MetricReporterFactory getInstance() {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricSchema.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricSchema.java
@@ -25,7 +25,5 @@ public enum MetricSchema {
     RESPONSE,
     ERROR,
     LATENCY,
-    PAYLOAD,
-    CUSTOM1,
-    CUSTOM2
+    PAYLOAD
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
@@ -59,56 +59,56 @@ public class DefaultAnalyticsMetricReporter extends AbstractMetricReporter {
     }
 
     private AmqpRetryOptions createRetryOptions(Map<String, String> properties) {
-        int maxRetries = 2;
-        int delay = 30;
-        int maxDelay = 120;
-        int tryTimeout = 60;
+        int maxRetries = Constants.DEFAULT_MAX_RETRIES;
+        int delay = Constants.DEFAULT_DELAY;
+        int maxDelay = Constants.DEFAULT_MAX_DELAY;
+        int tryTimeout = Constants.DEFAULT_TRY_TIMEOUT;
         AmqpRetryMode retryMode = AmqpRetryMode.FIXED;
-        if (properties.get("eventhub.client.max.retries") != null) {
-            int tempMaxRetries = Integer.parseInt(properties.get("eventhub.client.max.retries"));
+        if (properties.get(Constants.EVENTHUB_CLIENT_MAX_RETRIES) != null) {
+            int tempMaxRetries = Integer.parseInt(properties.get(Constants.EVENTHUB_CLIENT_MAX_RETRIES));
             if (tempMaxRetries > 0) {
                 maxRetries = tempMaxRetries;
             } else {
-                log.warn("Provided 'eventhub.client.max.retries' value is less than 0 and not acceptable. Hence using"
-                                 + " the default value.");
+                log.warn("Provided " + Constants.EVENTHUB_CLIENT_MAX_RETRIES + "value is less than 0 and not "
+                                 + "acceptable. Hence using the default value.");
             }
         }
-        if (properties.get("eventhub.client.delay") != null) {
-            int tempDelay = Integer.parseInt(properties.get("eventhub.client.delay"));
+        if (properties.get(Constants.EVENTHUB_CLIENT_DELAY) != null) {
+            int tempDelay = Integer.parseInt(properties.get(Constants.EVENTHUB_CLIENT_DELAY));
             if (tempDelay > 0) {
                 delay = tempDelay;
             } else {
-                log.warn("Provided 'eventhub.client.delay' value is less than 0 and not acceptable. Hence using"
-                                 + " the default value.");
+                log.warn("Provided " + Constants.EVENTHUB_CLIENT_DELAY + "value is less than 0 and not acceptable. "
+                                 + "Hence using the default value.");
             }
         }
-        if (properties.get("eventhub.client.max.delay") != null) {
-            int tempMaxDelay = Integer.parseInt(properties.get("eventhub.client.max.delay"));
+        if (properties.get(Constants.EVENTHUB_CLIENT_MAX_DELAY) != null) {
+            int tempMaxDelay = Integer.parseInt(properties.get(Constants.EVENTHUB_CLIENT_MAX_DELAY));
             if (tempMaxDelay > 0) {
                 maxDelay = tempMaxDelay;
             } else {
-                log.warn("Provided 'eventhub.client.max.delay' value is less than 0 and not acceptable. Hence using"
-                                 + " the default value.");
+                log.warn("Provided " + Constants.EVENTHUB_CLIENT_MAX_DELAY + "value is less than 0 and not acceptable. "
+                                 + "Hence using the default value.");
             }
         }
-        if (properties.get("eventhub.client.try.timeout") != null) {
-            int tempTryTimeout = Integer.parseInt(properties.get("eventhub.client.try.timeout"));
+        if (properties.get(Constants.EVENTHUB_CLIENT_TRY_TIMEOUT) != null) {
+            int tempTryTimeout = Integer.parseInt(properties.get(Constants.EVENTHUB_CLIENT_TRY_TIMEOUT));
             if (tempTryTimeout > 0) {
                 tryTimeout = tempTryTimeout;
             } else {
-                log.warn("Provided 'eventhub.client.try.timeout' value is less than 0 and not acceptable. Hence using"
-                                 + " the default value.");
+                log.warn("Provided " + Constants.EVENTHUB_CLIENT_TRY_TIMEOUT + "value is less than 0 and not "
+                                 + "acceptable. Hence using the default value.");
             }
         }
-        if (properties.get("eventhub.client.retry.mode") != null) {
-            String tempRetryMode = properties.get("eventhub.client.retry.mode");
-            if (tempRetryMode.equals("fixed")) {
+        if (properties.get(Constants.EVENTHUB_CLIENT_RETRY_MODE) != null) {
+            String tempRetryMode = properties.get(Constants.EVENTHUB_CLIENT_RETRY_MODE);
+            if (tempRetryMode.equals(Constants.FIXED)) {
                 //do nothing
-            } else if (tempRetryMode.equals("exponential")) {
+            } else if (tempRetryMode.equals(Constants.EXPONENTIAL)) {
                 retryMode = AmqpRetryMode.EXPONENTIAL;
             } else {
-                log.warn("Provided 'eventhub.client.retry.mode' value is not supported. Hence will using hte defalt "
-                                 + "value.");
+                log.warn("Provided " + Constants.EVENTHUB_CLIENT_RETRY_MODE + "value is not supported. Hence will "
+                                 + "using the default value.");
             }
         }
         return new AmqpRetryOptions()

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsThreadFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsThreadFactory.java
@@ -30,7 +30,7 @@ public class DefaultAnalyticsThreadFactory implements ThreadFactory {
     public DefaultAnalyticsThreadFactory(String threadPoolExecutorName) {
         SecurityManager s = System.getSecurityManager();
         group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
-        namePrefix = "Choreo-Analytics-" + threadPoolExecutorName + "-pool-" + poolNumber.getAndIncrement() +
+        namePrefix = "Cloud-Analytics-" + threadPoolExecutorName + "-pool-" + poolNumber.getAndIncrement() +
                 "-thread-";
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultCounterMetric.java
@@ -18,6 +18,7 @@
 
 package org.wso2.am.analytics.publisher.reporter.cloud;
 
+import org.wso2.am.analytics.publisher.client.ClientStatus;
 import org.wso2.am.analytics.publisher.exception.MetricCreationException;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
@@ -31,6 +32,7 @@ public class DefaultCounterMetric implements CounterMetric {
     private String name;
     private EventQueue queue;
     private MetricSchema schema;
+    private ClientStatus status;
 
     public DefaultCounterMetric(String name, EventQueue queue, MetricSchema schema) throws MetricCreationException {
         //Constructor should be made protected. Keeping public till testing plan is finalized
@@ -42,7 +44,7 @@ public class DefaultCounterMetric implements CounterMetric {
             throw new MetricCreationException("Default Counter Metric only supports " + MetricSchema.RESPONSE + " and"
                                                       + " " + MetricSchema.ERROR + " types.");
         }
-
+        this.status = queue.getClient().getStatus();
     }
 
     @Override
@@ -56,11 +58,15 @@ public class DefaultCounterMetric implements CounterMetric {
 
     @Override
     public int incrementCount(MetricEventBuilder builder) throws MetricReportingException {
-        if (builder != null) {
-            queue.put(builder);
-            return 0;
+        if (!(status == ClientStatus.NOT_CONNECTED)) {
+            if (builder != null) {
+                queue.put(builder);
+                return 0;
+            } else {
+                throw new MetricReportingException("MetricEventBuilder cannot be null");
+            }
         } else {
-            throw new MetricReportingException("MetricEventBuilder cannot be null");
+            throw new MetricReportingException("Eventhub Client is not connected.");
         }
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultFaultMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultFaultMetricEventBuilder.java
@@ -47,9 +47,10 @@ public class DefaultFaultMetricEventBuilder extends AbstractMetricEventBuilder {
                 throw new MetricReportingException(entry.getKey() + " is missing in metric data. This metric event "
                                                            + "will not be processed further.");
             } else if (!attribute.getClass().equals(entry.getValue())) {
-                    throw new MetricReportingException(entry.getKey() + " is expecting a " + entry.getValue() + " "
-                                                               + "type attribute while attribute of type "
-                                                               + attribute.getClass() + " is present.");
+                throw new MetricReportingException(entry.getKey() + " is expecting a " + entry.getValue() + " type "
+                                                           + "attribute while attribute of type " + attribute.getClass()
+                                                           + " is present");
+
             }
         }
         return true;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
@@ -49,9 +49,9 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
                 throw new MetricReportingException(entry.getKey() + " is missing in metric data. This metric event "
                                                            + "will not be processed further.");
             } else if (!attribute.getClass().equals(entry.getValue())) {
-                throw new MetricReportingException(entry.getKey() + " is expecting a " + entry.getValue() + " "
-                                                           + "type attribute while attribute of type "
-                                                           + attribute.getClass() + " is present.");
+                throw new MetricReportingException(entry.getKey() + " is expecting a " + entry.getValue() + " type "
+                                                           + "attribute while attribute of type " + attribute.getClass()
+                                                           + " is present.");
             }
         }
         return true;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/EventQueue.java
@@ -66,4 +66,8 @@ public class EventQueue {
         executorService.shutdown();
         super.finalize();
     }
+
+    protected EventHubClient getClient() {
+        return this.client;
+    }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/QueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/QueueWorker.java
@@ -62,14 +62,13 @@ public class QueueWorker implements Runnable {
                         event = new Gson().toJson(eventMap);
                     } catch (MetricReportingException e) {
                         log.error("Builder instance is not duly filled. Event building failed", e);
+                        continue;
                     }
                     client.sendEvent(event);
                 } else {
-                    //if we are done with consuming blocking queue flush the EventHub Client batch
-                    client.flushEvents();
                     break;
                 }
-                if (eventQueue.size() == 0) {
+                if (eventQueue.size() == 0 && threadPoolExecutor.getActiveCount() == 1) {
                     //if we are done with consuming blocking queue flush the EventHub Client batch
                     client.flushEvents();
                     break;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/BackoffRetryCounter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/BackoffRetryCounter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.util;
+
+/**
+ * Util class to implement backoff retrying.
+ */
+public class BackoffRetryCounter {
+    private final String[] timeIntervalNames = new String[]{"5 sec", "10 sec", "15 sec", "30 sec", "1 min", "1 min",
+                                                            "2 min", "5 min"};
+    private final long[] timeIntervals = new long[]{5000, 10000, 15000, 30000, 60000, 60000, 120000, 300000};
+
+    private int intervalIndex = 0;
+
+    public synchronized void reset() {
+        intervalIndex = 0;
+    }
+
+    public synchronized void increment() {
+        if (intervalIndex < timeIntervals.length - 1) {
+            intervalIndex++;
+        }
+    }
+
+    public long getTimeIntervalMillis() {
+        return timeIntervals[intervalIndex];
+    }
+
+
+    public String getTimeInterval() {
+        return timeIntervalNames[intervalIndex];
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -21,8 +21,7 @@ package org.wso2.am.analytics.publisher.util;
  * Class to hold String constants
  */
 public class Constants {
-    public static final String CHOREO_ANALYTICS_REPORTER_FQCN = "org.wso2.am.analytics.publisher.reporter"
-            + ".ChoreoAnalyticsMetricReporter";
+    //Event attribute names
     public static final String CORRELATION_ID = "correlationId";
     public static final String KEY_TYPE = "keyType";
     public static final String API_ID = "apiId";
@@ -36,7 +35,6 @@ public class Constants {
     public static final String DESTINATION = "destination";
     public static final String APPLICATION_ID = "applicationId";
     public static final String APPLICATION_NAME = "applicationName";
-    public static final String APPLICATION_CONSUMER_KEY = "applicationConsumerKey";
     public static final String APPLICATION_OWNER = "applicationOwner";
     public static final String REGION_ID = "regionId";
     public static final String GATEWAY_TYPE = "gatewayType";
@@ -54,21 +52,33 @@ public class Constants {
     public static final String EVENT_TYPE = "eventType";
     public static final String API_TYPE = "apiType";
     public static final String USER_IP = "userIp";
-
-    public static final String RESPONSE_EVENT_TYPE = "response";
-    public static final String FAULT_EVENT_TYPE = "fault";
-
     public static final String ERROR_TYPE = "errorType";
     public static final String ERROR_CODE = "errorCode";
     public static final String ERROR_MESSAGE = "errorMessage";
 
+    //Builder event types
+    public static final String RESPONSE_EVENT_TYPE = "response";
+    public static final String FAULT_EVENT_TYPE = "fault";
+
+    //Reporter config properties
     public static final String AUTH_API_URL = "auth.api.url";
     public static final String AUTH_API_TOKEN = "auth.api.token";
-    public static final String TOKEN_API_URL = "token.api.url";
-    public static final String CONSUMER_KEY = "consumer.key";
-    public static final String CONSUMER_SECRET = "consumer.secret";
-    public static final String SAS_TOKEN = "sas.token";
+
+    //Reporter constants
     public static final String DEFAULT_REPORTER = "default";
+
+    //EventHub Client retry options constants
+    public static final int DEFAULT_MAX_RETRIES = 2;
+    public static final int DEFAULT_DELAY = 30;
+    public static final int DEFAULT_MAX_DELAY = 120;
+    public static final int DEFAULT_TRY_TIMEOUT = 60;
+    public static final String EVENTHUB_CLIENT_MAX_RETRIES = "eventhub.client.max.retries";
+    public static final String EVENTHUB_CLIENT_DELAY = "eventhub.client.delay";
+    public static final String EVENTHUB_CLIENT_MAX_DELAY = "eventhub.client.max.delay";
+    public static final String EVENTHUB_CLIENT_TRY_TIMEOUT = "eventhub.client.try.timeout";
+    public static final String EVENTHUB_CLIENT_RETRY_MODE = "eventhub.client.retry.mode";
+    public static final String FIXED = "fixed";
+    public static final String EXPONENTIAL = "exponential";
 
     public static final String UNKNOWN_VALUE = "UNKNOWN";
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
@@ -20,7 +20,9 @@ package org.wso2.am.analytics.publisher;
 
 import org.apache.log4j.Logger;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.am.analytics.publisher.client.EventHubClient;
 import org.wso2.am.analytics.publisher.exception.MetricCreationException;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
@@ -35,21 +37,23 @@ import java.util.Map;
 
 public class DefaultFaultMetricBuilderTestCase {
     private static final Logger log = Logger.getLogger(DefaultFaultMetricBuilderTestCase.class);
+    private MetricEventBuilder builder;
+    @BeforeMethod
+    public void createBuilder() throws MetricCreationException {
+        EventHubClient client = new EventHubClient("some_endpoint", "some_token");
+        EventQueue queue = new EventQueue(100, 1, client);
+        DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue, MetricSchema.ERROR);
+        builder = metric.getEventBuilder();
+    }
 
     @Test(expectedExceptions = MetricReportingException.class)
     public void testMissingAttributes() throws MetricCreationException, MetricReportingException {
-        EventQueue queue = new EventQueue(100, 1, null);
-        DefaultCounterMetric metric = new DefaultCounterMetric("test.metric", queue, MetricSchema.ERROR);
-        MetricEventBuilder builder = metric.getEventBuilder();
         builder.addAttribute("apiName", "PizzaShack");
         builder.build();
     }
 
     @Test(expectedExceptions = MetricReportingException.class)
     public void testAttributesWithInvalidTypes() throws MetricCreationException, MetricReportingException {
-        EventQueue queue = new EventQueue(100, 1, null);
-        DefaultCounterMetric metric = new DefaultCounterMetric("test.metric", queue, MetricSchema.ERROR);
-        MetricEventBuilder builder = metric.getEventBuilder();
         builder.addAttribute(Constants.REQUEST_TIMESTAMP, System.currentTimeMillis())
                 .addAttribute(Constants.CORRELATION_ID, "1234-4567")
                 .addAttribute(Constants.KEY_TYPE, "prod")
@@ -75,9 +79,6 @@ public class DefaultFaultMetricBuilderTestCase {
 
     @Test
     public void testMetricBuilder() throws MetricCreationException, MetricReportingException {
-        EventQueue queue = new EventQueue(100, 1, null);
-        DefaultCounterMetric metric = new DefaultCounterMetric("test.metric", queue, MetricSchema.ERROR);
-        MetricEventBuilder builder = metric.getEventBuilder();
         Map<String, Object> eventMap = builder
                 .addAttribute(Constants.REQUEST_TIMESTAMP, OffsetDateTime.now(Clock.systemUTC()).toString())
                 .addAttribute(Constants.CORRELATION_ID, "1234-4567")

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/ErrorHandlingTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/ErrorHandlingTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher;
+
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.am.analytics.publisher.client.EventHubClient;
+import org.wso2.am.analytics.publisher.exception.MetricCreationException;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.MetricReporter;
+import org.wso2.am.analytics.publisher.reporter.MetricReporterFactory;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.am.analytics.publisher.util.Constants;
+import org.wso2.am.analytics.publisher.util.UnitTestAppender;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ErrorHandlingTestCase {
+
+    @Test
+    public void testConnectionUnavailability() throws MetricCreationException, MetricReportingException {
+        boolean errorOccurred = false;
+        String message = "";
+        UnitTestAppender appender = new UnitTestAppender();
+        Logger log = Logger.getLogger(EventHubClient.class);
+        log.addAppender(appender);
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(Constants.AUTH_API_URL, "some_url");
+        configMap.put(Constants.AUTH_API_TOKEN, "some_token");
+        MetricReporter metricReporter = MetricReporterFactory.getInstance().createMetricReporter(configMap);
+        CounterMetric metric = metricReporter.createCounterMetric("test-connection-counter", MetricSchema.RESPONSE);
+        MetricEventBuilder builder = metric.getEventBuilder();
+        builder.addAttribute("some_key", "some_value");
+        try {
+            metric.incrementCount(builder);
+        } catch (MetricReportingException e) {
+            errorOccurred = true;
+            message = e.getMessage();
+        }
+        Assert.assertTrue(errorOccurred, "MetricReportingException should be thrown");
+        Assert.assertTrue(message.contains("Eventhub Client is not connected."), "Expected error hasn't thrown.");
+        Assert.assertTrue(appender.getMessages().contains("Unrecoverable error occurred when creating Eventhub "
+                                                                  + "Client"), "Expected error hasn't logged in the "
+                                  + "EventHubClientClass");
+    }
+}

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/LogMetricReporterTestCase.java
@@ -48,12 +48,12 @@ public class LogMetricReporterTestCase {
                                                                                                     "value3");
         metric.incrementCount(builder);
 
-        Assert.assertTrue(appender.getMessages().contains("testCounter"), "Metric name is not properly logged");
-        Assert.assertTrue(appender.getMessages().contains("attribute1=value1"), "Metric attribute is not properly "
+        Assert.assertTrue(appender.checkContains("testCounter"), "Metric name is not properly logged");
+        Assert.assertTrue(appender.checkContains("attribute1=value1"), "Metric attribute is not properly "
                 + "logged");
-        Assert.assertTrue(appender.getMessages().contains("attribute2=value2"), "Metric attribute is not properly "
+        Assert.assertTrue(appender.checkContains("attribute2=value2"), "Metric attribute is not properly "
                 + "logged");
-        Assert.assertTrue(appender.getMessages().contains("attribute3=value3"), "Metric attribute is not properly "
+        Assert.assertTrue(appender.checkContains("attribute3=value3"), "Metric attribute is not properly "
                 + "logged");
     }
 

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MetricReporterTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MetricReporterTestCase.java
@@ -27,6 +27,8 @@ import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.reporter.MetricReporter;
 import org.wso2.am.analytics.publisher.reporter.MetricReporterFactory;
 import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.am.analytics.publisher.util.Constants;
+import org.wso2.am.analytics.publisher.util.TestUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -79,6 +81,28 @@ public class MetricReporterTestCase {
         configs.put("consumer.secret", "some_secret");
         configs.put("consumer.key", "");
         createAndPublish(configs, null);
+    }
+
+    @Test
+    public void testCompleteFlow() throws MetricCreationException, MetricReportingException, InterruptedException {
+        Map<String, String> configMap = new HashMap<>();
+        String authURL = System.getenv(Constants.AUTH_API_URL);
+        String authToken = System.getenv(Constants.AUTH_API_TOKEN);
+        if (authToken != null && authURL != null) {
+            configMap.put(Constants.AUTH_API_URL, authURL);
+            configMap.put(Constants.AUTH_API_TOKEN, authToken);
+        } else {
+            return;
+        }
+        MetricReporter metricReporter = MetricReporterFactory.getInstance().createMetricReporter(configMap);
+        CounterMetric metric = metricReporter.createCounterMetric("test-connection-counter", MetricSchema.RESPONSE);
+        for (int i = 0; i < 5; i++) {
+            MetricEventBuilder builder = metric.getEventBuilder();
+            TestUtils.populateBuilder(builder);
+            metric.incrementCount(builder);
+        }
+        Thread.sleep(2000);
+        //Assertions will be done after mocking eventhub client
     }
 
 

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/TestUtils.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/TestUtils.java
@@ -57,6 +57,6 @@ public class TestUtils {
                 .addAttribute(Constants.BACKEND_LATENCY, 3000L)
                 .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, 1000L)
                 .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000L)
-                .addAttribute(Constants.DEPLOYMENT_ID, "prod");
+                .addAttribute(Constants.USER_IP, "127.0.0.1");
     }
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/TestUtils.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/TestUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.util;
+
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+/**
+ * Util class  containing helper methods for test
+ */
+public class TestUtils {
+    public static void populateBuilder(MetricEventBuilder builder) throws MetricReportingException {
+        String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, "
+                + "like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
+
+        builder.addAttribute(Constants.REQUEST_TIMESTAMP, OffsetDateTime.now(Clock.systemUTC()).toString())
+                .addAttribute(Constants.CORRELATION_ID, "1234-4567")
+                .addAttribute(Constants.KEY_TYPE, "prod")
+                .addAttribute(Constants.API_ID, "9876-54f1")
+                .addAttribute(Constants.API_TYPE, "HTTP")
+                .addAttribute(Constants.API_NAME, "PizzaShack")
+                .addAttribute(Constants.API_VERSION, "1.0.0")
+                .addAttribute(Constants.API_CREATION, "admin")
+                .addAttribute(Constants.API_METHOD, "POST")
+                .addAttribute(Constants.API_RESOURCE_TEMPLATE, "/resource/{value}")
+                .addAttribute(Constants.API_CREATOR_TENANT_DOMAIN, "carbon.super")
+                .addAttribute(Constants.DESTINATION, "localhost:8080")
+                .addAttribute(Constants.APPLICATION_ID, "3445-6778")
+                .addAttribute(Constants.APPLICATION_NAME, "default")
+                .addAttribute(Constants.APPLICATION_OWNER, "admin")
+                .addAttribute(Constants.REGION_ID, "NA")
+                .addAttribute(Constants.GATEWAY_TYPE, "Synapse")
+                .addAttribute(Constants.USER_AGENT_HEADER, uaString)
+                .addAttribute(Constants.PROXY_RESPONSE_CODE, 401)
+                .addAttribute(Constants.TARGET_RESPONSE_CODE, 401)
+                .addAttribute(Constants.RESPONSE_CACHE_HIT, true)
+                .addAttribute(Constants.RESPONSE_LATENCY, 2000L)
+                .addAttribute(Constants.BACKEND_LATENCY, 3000L)
+                .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, 1000L)
+                .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000L)
+                .addAttribute(Constants.DEPLOYMENT_ID, "prod");
+    }
+}

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/UnitTestAppender.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/UnitTestAppender.java
@@ -20,12 +20,15 @@ package org.wso2.am.analytics.publisher.util;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class UnitTestAppender extends AppenderSkeleton {
-    private String messages;
+    private List<String> messages = new ArrayList<>();
 
     @Override
     protected void append(LoggingEvent loggingEvent) {
-        messages = loggingEvent.getRenderedMessage();
+        messages.add(loggingEvent.getRenderedMessage());
     }
 
     @Override
@@ -37,7 +40,16 @@ public class UnitTestAppender extends AppenderSkeleton {
         return false;
     }
 
-    public String getMessages() {
+    public List<String> getMessages() {
         return messages;
+    }
+
+    public boolean checkContains(String message) {
+        for (String log : messages) {
+            if (log.contains(message)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/component/publisher-client/src/test/resources/testng.xml
+++ b/component/publisher-client/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
             <class name="org.wso2.am.analytics.publisher.LogMetricReporterTestCase"/>
             <class name="org.wso2.am.analytics.publisher.DefaultResponseMetricBuilderTestCase"/>
             <class name="org.wso2.am.analytics.publisher.DefaultFaultMetricBuilderTestCase"/>
+            <class name="org.wso2.am.analytics.publisher.ErrorHandlingTestCase"/>
         </classes>
     </test>
 </suite>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -22,4 +22,16 @@
         <Class name="org.wso2.am.analytics.publisher.reporter.cloud.EventQueue"/>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.client.EventHubClient"/>
+        <Bug pattern="IMSE_DONT_CATCH_IMSE"/>
+    </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.client.EventHubClient"/>
+        <Bug pattern="WA_NOT_IN_LOOP"/>
+    </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.util.BackoffRetryCounter"/>
+        <Bug pattern="IS2_INCONSISTENT_SYNC"/>
+    </Match>
 </FindBugsFilter>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -28,7 +28,7 @@
     </Match>
     <Match>
         <Class name="org.wso2.am.analytics.publisher.client.EventHubClient"/>
-        <Bug pattern="WA_NOT_IN_LOOP"/>
+        <Bug pattern="WA_AWAIT_NOT_IN_LOOP"/>
     </Match>
     <Match>
         <Class name="org.wso2.am.analytics.publisher.util.BackoffRetryCounter"/>


### PR DESCRIPTION
## Purpose
This PR adds error handling capabilities to publisher clients. More information is available under below issue
Addresses issue https://github.com/wso2/apim-analytics-publisher/issues/30

## Approach
Approach taken to each error scenario will be explained
**Scenario 01 - Network loss when starting up the instance**

- Deployer threads will encounter this issues when trying to create a Metric.
- Upon receiving connectivity exception deployer will return handling over the retrying task to another thread
- EventHubClient status will be marked as Retrying and any publisher thread which tries to publish will wait on condition
- Once retrying task is successful publisher thread will be notified and publishing will commence

**Scenario 02 - Authentication failure when starting up the instance**

- Deployer threads will encounter this issues when trying to create a Metric.
- Upon receiving authentication error deployer thread will return and mark the Metric as inactive
- PT threads will drop events at the Metric even before events are added to the async Queue
- System wont recover until a restart

**Scenario 03 - Intermittent connection issue to event hub**

- Publisher threads will encounter the connectivity issue when trying to publish
- By default it will retry 2 times with 60 sec timeouts and 30 sec delays in between.
- In case of failure will hand over the task to next publisher thread waiting in line
- Will keep on retrying like this till connection is made

**Scenario 04 - Intermittent authentication issue due to authentication service down time**

- Token refresh thread will encounter this issue
- Once encountered refresh thread will start retrying to get the new token. 
- If retrying is successful before current token expiry publisher threads will continue as ususal
- If retrying is not successful publishing threads will encounter authentication exceptions
- Threads will mark EventHubClient status as retrying, try to initiate new publisher and park themselves
- New publisher creation will keep on retrying till a connection is made and once connection is made will notify waitin publisher threads.

**Scenario 05 - Unexpected authentication issue due to user revocation(user token and publisher)**

- Publishing threads will encounter authentication exceptions
- Threads will mark EventHubClient status as retrying, try to initiate new publisher and park themselves
- New publisher creation will receive authentication exception too and retying will be abandoned after printing an error log. Events will start dropping once queue is filled.

**Scenario 06 - Unexpected authentication issue due to publisher suspension(publisher)**

- Publishing threads will encounter authentication exceptions
- Threads will mark EventHubClient status as retrying, try to initiate new publisher and park themselves
- New publisher creation will receive forbidden response code and retying will be started until successful response is received. 
- Upon receiving successful response publisher threads will be notified

**Scenario 07 - Any other exception when getting getting token**

- Connection will be retries

**Scenario 08 - Resource limitations exception when publishing events**

- Publishing threads will sleep for sometime and retry publishing again

**Scenario 09 - Any other exception when publishing events**

- Event producer client will be re-created discarding the current batch of events
- Events may be loss during this step

## Automation tests
 - Unit tests 
   > 78% classes 53% lines

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
