### PR TITLE
Event Flushing Service

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
@@ -52,11 +52,11 @@ public class EventHubClient {
     private final BackoffRetryCounter eventBatchRetryCounter;
     private final Lock threadBarrier;
     private final AmqpRetryOptions retryOptions;
-    private Condition waitCondition;
+    private final Condition waitCondition;
     private EventHubProducerClient producer;
     private EventDataBatch batch;
     private ClientStatus clientStatus;
-    private ScheduledExecutorService scheduledExecutorService;
+    private final ScheduledExecutorService scheduledExecutorService;
 
     public EventHubClient(String authEndpoint, String authToken, AmqpRetryOptions retryOptions) {
         threadBarrier = new ReentrantLock();

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
@@ -28,6 +28,7 @@ import org.wso2.am.analytics.publisher.exception.ConnectionRecoverableException;
 import org.wso2.am.analytics.publisher.exception.ConnectionUnrecoverableException;
 import org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsThreadFactory;
 import org.wso2.am.analytics.publisher.util.BackoffRetryCounter;
+import org.wso2.am.analytics.publisher.util.Constants;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -85,6 +86,7 @@ public class EventHubClient {
 
     private void createProducerWithRetry(String authEndpoint, String authToken,
                                          AmqpRetryOptions retryOptions, boolean createBatch) {
+        log.debug("Creating Eventhub client instance.");
         try {
             if (producer != null) {
                 producer.close();
@@ -99,6 +101,7 @@ public class EventHubClient {
                         .replaceAll("[\r\n]", ""));
             }
             clientStatus = ClientStatus.CONNECTED;
+            log.info("Eventhub client successfully connected.");
             producerRetryCounter.reset();
             try {
                 threadBarrier.lock();
@@ -108,7 +111,8 @@ public class EventHubClient {
             }
         } catch (ConnectionRecoverableException e) {
             clientStatus = ClientStatus.RETRYING;
-            log.error("Recoverable error occurred when creating Eventhub Client. Retry attempts will be made. Reason :"
+            log.error("Recoverable error occurred when creating Eventhub Client. Retry attempts will be made in "
+                              + producerRetryCounter.getTimeInterval().replaceAll("[\r\n]", "") + ". Reason :"
                               + e.getMessage().replaceAll("[\r\n]", ""));
             if (log.isDebugEnabled()) {
                 log.debug("Recoverable error occurred when creating Eventhub Client using following attributes. Auth "
@@ -143,24 +147,25 @@ public class EventHubClient {
                         isAdded = batch.tryAdd(eventData);
                         if (!isAdded) {
                             int size = batch.getCount();
+                            log.debug("Publishing " + size + " events to Analytics cluster.");
                             producer.send(batch);
                             batch = createBatchWithRetry();
                             isAdded = batch.tryAdd(eventData);
-                            log.info("Published " + size + " events to Analytics cluster.");
+                            log.debug("Published " + size + " events to Analytics cluster.");
                         }
                     } catch (AmqpException e) {
                         if (isAuthenticationFailure(e)) {
                             //if authentication error try to reinitialize publisher. Retrying will deal with any
                             // network or revocation failures.
                             log.error("Authentication issue happened. Producer client will be re-initialized "
-                                              + "retaining the EventDataBatch");
+                                              + "retaining the Event Data Batch");
                             this.clientStatus = ClientStatus.RETRYING;
                             createProducerWithRetry(authEndpoint, authToken, retryOptions, false);
                             readWriteLock.writeLock().unlock();
                             sendEvent(event);
                         } else if (e.getErrorCondition() == AmqpErrorCondition.RESOURCE_LIMIT_EXCEEDED) {
                             //If resource limit is exceeded we will retry after a constant delay
-                            log.error("Resource limit exceeded when publishing EventDataBatch. Operation will be "
+                            log.error("Resource limit exceeded when publishing Event Data Batch. Operation will be "
                                               + "retried after constant delay");
                             try {
                                 Thread.sleep(1000 * 60);
@@ -171,7 +176,7 @@ public class EventHubClient {
                             sendEvent(event);
                         } else {
                             //For any other exception
-                            log.error("Unknown error occurred while publishing EventDataBatch. Producer client will "
+                            log.error("Unknown error occurred while publishing Event Data Batch. Producer client will "
                                               + "be re-initialized. Events may be lost in the process.");
                             this.clientStatus = ClientStatus.RETRYING;
                             readWriteLock.writeLock().unlock();
@@ -180,14 +185,14 @@ public class EventHubClient {
                     } catch (Exception e) {
                         if (e.getCause() instanceof TimeoutException) {
                             log.error("Timeout occurred after retrying " + retryOptions.getMaxRetries() + " "
-                                              + "times with an timeout of " + retryOptions.getTryTimeout() + " "
-                                              + "seconds while trying to publish EventDataBatch. Next retry cycle "
+                                              + "times with an timeout of " + retryOptions.getTryTimeout().getSeconds()
+                                              + " seconds while trying to publish Event Data Batch. Next retry cycle "
                                               + "will begin shortly.");
                             readWriteLock.writeLock().unlock();
                             sendEvent(event);
                         } else {
                             //For any other exception
-                            log.error("Unknown error occurred while publishing EventDataBatch. Producer client will "
+                            log.error("Unknown error occurred while publishing Event Data Batch. Producer client will "
                                               + "be re-initialized. Events may be lost in the process.");
                             this.clientStatus = ClientStatus.RETRYING;
                             readWriteLock.writeLock().unlock();
@@ -202,12 +207,12 @@ public class EventHubClient {
                     }
                 }
                 if (isAdded) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Adding event: " + event.replaceAll("[\r\n]", ""));
+                    if (log.isTraceEnabled()) {
+                        log.trace("Adding event: " + event.replaceAll("[\r\n]", ""));
                     }
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Failed to add event: " + event.replaceAll("[\r\n]", ""));
+                    if (log.isTraceEnabled()) {
+                        log.trace("Failed to add event: " + event.replaceAll("[\r\n]", ""));
                     }
                 }
             } finally {
@@ -245,12 +250,13 @@ public class EventHubClient {
     }
 
     private EventDataBatch createBatchWithRetry() {
+        log.debug("Creating Event Data Batch");
         try {
             EventDataBatch batch = producer.createBatch();
             eventBatchRetryCounter.reset();
             return batch;
         } catch (IllegalStateException e) {
-            log.error("Error in creating EventDataBatch. Will be retried in "
+            log.error("Error in creating Event Data Batch. Operation will be retried in "
                               + eventBatchRetryCounter.getTimeInterval().replaceAll("[\r\n]", ""));
             try {
                 Thread.sleep(eventBatchRetryCounter.getTimeIntervalMillis());
@@ -265,18 +271,27 @@ public class EventHubClient {
     public void flushEvents() {
         if (this.clientStatus == ClientStatus.CONNECTED && batch.getCount() > 0) {
             try {
+                log.debug("Starting to flush Event Data Batch");
                 //work on retrying
-                readWriteLock.writeLock().lock();
-                int size = batch.getCount();
-                producer.send(batch);
-                batch = createBatchWithRetry();
-                log.debug("Flushed " + size + " events to Analytics cluster.");
+                if (readWriteLock.writeLock().tryLock(Constants.DEFAULT_LOCK_TIMEOUT, TimeUnit.SECONDS)) {
+                    int size = batch.getCount();
+                    producer.send(batch);
+                    batch = createBatchWithRetry();
+                    log.debug("Flushed " + size + " events to Analytics cluster.");
+                } else {
+                    log.error("Event flushing operation aborted as publisher threads are trying to send events");
+                }
             } catch (Exception e) {
+                log.error("Event flushing operation failed. Will be retried again according to the configured "
+                                  + "client.flushing.delay. Error will be handled by publishing threads once "
+                                  + "Event Data Batch is filled.");
                 //Dont do anything for any exception. If it is recoverable exception next run will succeed.
                 //If not recoverable then next run will be filtered by if condition
             } finally {
                 readWriteLock.writeLock().unlock();
             }
+        } else {
+            log.debug("Event flushing is aborted as Event Data Batch is empty or connection to Event Hub is not made");
         }
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporter.java
@@ -52,10 +52,4 @@ public interface MetricReporter {
      */
     Map<String, String> getConfiguration();
 
-    /**
-     * Returns a {@link MetricReporter} instance representing the provided properties. This mandate every
-     * MetricReporter implementation to adhere to Singleton pattern.
-     * @param properties properties required by the MetricReporter
-     * @return {@link MetricReporter} instance
-     */
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
@@ -45,17 +45,21 @@ public class DefaultAnalyticsMetricReporter extends AbstractMetricReporter {
         super(properties);
         int queueSize = 20000;
         int workerThreads = 5;
-        if (properties.get("queue.size") != null) {
-            queueSize = Integer.parseInt(properties.get("queue.size"));
+        int flushingDelay = 10;
+        if (properties.get(Constants.QUEUE_SIZE) != null) {
+            queueSize = Integer.parseInt(properties.get(Constants.QUEUE_SIZE));
         }
-        if (properties.get("worker.thread.count") != null) {
-            workerThreads = Integer.parseInt(properties.get("worker.thread.count"));
+        if (properties.get(Constants.WORKER_THREAD_COUNT) != null) {
+            workerThreads = Integer.parseInt(properties.get(Constants.WORKER_THREAD_COUNT));
+        }
+        if (properties.get(Constants.CLIENT_FLUSHING_DELAY) != null) {
+            flushingDelay = Integer.parseInt(properties.get(Constants.CLIENT_FLUSHING_DELAY));
         }
         String authToken = properties.get(Constants.AUTH_API_TOKEN);
         String authEndpoint = properties.get(Constants.AUTH_API_URL);
         AmqpRetryOptions retryOptions = createRetryOptions(properties);
         EventHubClient client = new EventHubClient(authEndpoint, authToken, retryOptions);
-        eventQueue = new EventQueue(queueSize, workerThreads, client);
+        eventQueue = new EventQueue(queueSize, workerThreads, client, flushingDelay);
     }
 
     private AmqpRetryOptions createRetryOptions(Map<String, String> properties) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
@@ -43,9 +43,9 @@ public class DefaultAnalyticsMetricReporter extends AbstractMetricReporter {
 
     public DefaultAnalyticsMetricReporter(Map<String, String> properties) throws MetricCreationException {
         super(properties);
-        int queueSize = 20000;
-        int workerThreads = 5;
-        int flushingDelay = 10;
+        int queueSize = Constants.DEFAULT_QUEUE_SIZE;
+        int workerThreads = Constants.DEFAULT_WORKER_THREADS;
+        int flushingDelay = Constants.DEFAULT_FLUSHING_DELAY;
         if (properties.get(Constants.QUEUE_SIZE) != null) {
             queueSize = Integer.parseInt(properties.get(Constants.QUEUE_SIZE));
         }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultCounterMetric.java
@@ -59,12 +59,8 @@ public class DefaultCounterMetric implements CounterMetric {
     @Override
     public int incrementCount(MetricEventBuilder builder) throws MetricReportingException {
         if (!(status == ClientStatus.NOT_CONNECTED)) {
-            if (builder != null) {
-                queue.put(builder);
-                return 0;
-            } else {
-                throw new MetricReportingException("MetricEventBuilder cannot be null");
-            }
+            queue.put(builder);
+            return 0;
         } else {
             throw new MetricReportingException("Eventhub Client is not connected.");
         }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/QueueFlusher.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/QueueFlusher.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.reporter.cloud;
+
+import org.wso2.am.analytics.publisher.client.EventHubClient;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Class to periodically flush event batch
+ */
+public class QueueFlusher implements Runnable {
+
+    private final BlockingQueue<MetricEventBuilder> queue;
+    private final EventHubClient client;
+
+    public QueueFlusher(BlockingQueue<MetricEventBuilder> queue, EventHubClient client) {
+        this.queue = queue;
+        this.client = client;
+    }
+
+    @Override public void run() {
+        if (queue.isEmpty()) {
+            //For scenarios where no API invocation is happening additional check in the EventHubClient will stop
+            // empty batch flushing
+            client.flushEvents();
+        }
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/QueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/QueueWorker.java
@@ -56,7 +56,7 @@ public class QueueWorker implements Runnable {
             do {
                 MetricEventBuilder eventBuilder = eventQueue.poll();
                 if (eventBuilder != null) {
-                    String event = null;
+                    String event;
                     try {
                         Map<String, Object> eventMap = eventBuilder.build();
                         event = new Gson().toJson(eventMap);
@@ -66,11 +66,7 @@ public class QueueWorker implements Runnable {
                     }
                     client.sendEvent(event);
                 } else {
-                    break;
-                }
-                if (eventQueue.size() == 0 && threadPoolExecutor.getActiveCount() == 1) {
-                    //if we are done with consuming blocking queue flush the EventHub Client batch
-                    client.flushEvents();
+                    log.error("Builder instance is null");
                     break;
                 }
             } while (threadPoolExecutor.getActiveCount() == 1 && eventQueue.size() != 0);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -69,9 +69,9 @@ public class Constants {
 
     //EventHub Client retry options constants
     public static final int DEFAULT_MAX_RETRIES = 2;
-    public static final int DEFAULT_DELAY = 30;
-    public static final int DEFAULT_MAX_DELAY = 120;
-    public static final int DEFAULT_TRY_TIMEOUT = 60;
+    public static final int DEFAULT_DELAY = 15;
+    public static final int DEFAULT_MAX_DELAY = 30;
+    public static final int DEFAULT_TRY_TIMEOUT = 30;
     public static final String EVENTHUB_CLIENT_MAX_RETRIES = "eventhub.client.max.retries";
     public static final String EVENTHUB_CLIENT_DELAY = "eventhub.client.delay";
     public static final String EVENTHUB_CLIENT_MAX_DELAY = "eventhub.client.max.delay";
@@ -84,4 +84,8 @@ public class Constants {
     public static final String WORKER_THREAD_COUNT = "worker.thread.count";
     public static final String QUEUE_SIZE = "queue.size";
     public static final String CLIENT_FLUSHING_DELAY = "client.flushing.delay";
+    public static final int DEFAULT_QUEUE_SIZE = 20000;
+    public static final int DEFAULT_WORKER_THREADS = 5;
+    public static final int DEFAULT_FLUSHING_DELAY = 15;
+    public static final int DEFAULT_LOCK_TIMEOUT = 30;
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -81,4 +81,7 @@ public class Constants {
     public static final String EXPONENTIAL = "exponential";
 
     public static final String UNKNOWN_VALUE = "UNKNOWN";
+    public static final String WORKER_THREAD_COUNT = "worker.thread.count";
+    public static final String QUEUE_SIZE = "queue.size";
+    public static final String CLIENT_FLUSHING_DELAY = "client.flushing.delay";
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
@@ -51,7 +51,7 @@ public class DefaultFaultMetricBuilderTestCase {
                 .setTryTimeout(Duration.ofSeconds(30))
                 .setMode(AmqpRetryMode.FIXED);
         EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions);
-        EventQueue queue = new EventQueue(100, 1, client);
+        EventQueue queue = new EventQueue(100, 1, client, 10);
         DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue, MetricSchema.ERROR);
         builder = metric.getEventBuilder();
     }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultResponseMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultResponseMetricBuilderTestCase.java
@@ -52,7 +52,7 @@ public class DefaultResponseMetricBuilderTestCase {
                 .setTryTimeout(Duration.ofSeconds(30))
                 .setMode(AmqpRetryMode.FIXED);
         EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions);
-        EventQueue queue = new EventQueue(100, 1, client);
+        EventQueue queue = new EventQueue(100, 1, client, 10);
         DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue, MetricSchema.RESPONSE);
         builder = metric.getEventBuilder();
     }

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -31,6 +31,10 @@
         <Bug pattern="WA_AWAIT_NOT_IN_LOOP"/>
     </Match>
     <Match>
+        <Class name="org.wso2.am.analytics.publisher.client.EventHubClient"/>
+        <Bug pattern="REC_CATCH_EXCEPTION"/>
+    </Match>
+    <Match>
         <Class name="org.wso2.am.analytics.publisher.util.BackoffRetryCounter"/>
         <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/apim-analytics-publisher/issues/41
Improves debug logging

## Approach
Introduced a new scheduler thread which will periodically check the blocking event queue and if the queue is empty will check the EventDataBatch. If batch is non empty it will publish the batch. Time interval is configurable
Property name : client.flushing.delay
Default value : 10 seconds
Time unit : seconds
Accepts : integer

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
