### PR TITLE
Adds parallel eventhub producer clients

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubClient.java
@@ -295,8 +295,10 @@ public class EventHubClient implements Cloneable {
                                + "flushing operation aborted as publisher threads are trying to send events");
                 }
         } else {
-            log.debug("[{ " + Thread.currentThread().getName().replaceAll("[\r\n]", "") + " }] Event flushing "
-                              + "is aborted as Event Data Batch is empty or connection to Event Hub is not made");
+            if (log.isDebugEnabled()) {
+                log.debug("[{ " + Thread.currentThread().getName().replaceAll("[\r\n]", "") + " }] Event flushing "
+                                  + "is aborted as Event Data Batch is empty or connection to Event Hub is not made");
+            }
         }
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -85,8 +85,7 @@ public class Constants {
     public static final String QUEUE_SIZE = "queue.size";
     public static final String CLIENT_FLUSHING_DELAY = "client.flushing.delay";
     public static final int DEFAULT_QUEUE_SIZE = 20000;
-    public static final int DEFAULT_WORKER_THREADS = 5;
+    public static final int DEFAULT_WORKER_THREADS = 1;
     public static final int DEFAULT_FLUSHING_DELAY = 15;
-    public static final int DEFAULT_LOCK_TIMEOUT = 30;
     public static final int USER_AGENT_DEFAULT_CACHE_SIZE = 50;
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/ErrorHandlingTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/ErrorHandlingTestCase.java
@@ -41,8 +41,6 @@ public class ErrorHandlingTestCase {
 
     @Test
     public void testConnectionInvalidURL() throws MetricCreationException, MetricReportingException {
-        boolean errorOccurred = false;
-        String message = "";
         UnitTestAppender appender = new UnitTestAppender();
         Logger log = Logger.getLogger(EventHubClient.class);
         log.addAppender(appender);
@@ -52,16 +50,6 @@ public class ErrorHandlingTestCase {
         configMap.put(Constants.AUTH_API_TOKEN, "some_token");
         MetricReporter metricReporter = MetricReporterFactory.getInstance().createMetricReporter(configMap);
         CounterMetric metric = metricReporter.createCounterMetric("test-connection-counter", MetricSchema.RESPONSE);
-        MetricEventBuilder builder = metric.getEventBuilder();
-        builder.addAttribute("some_key", "some_value");
-        try {
-            metric.incrementCount(builder);
-        } catch (MetricReportingException e) {
-            errorOccurred = true;
-            message = e.getMessage();
-        }
-        Assert.assertTrue(errorOccurred, "MetricReportingException should be thrown");
-        Assert.assertTrue(message.contains("Eventhub Client is not connected."), "Expected error hasn't thrown.");
         Assert.assertTrue(appender.checkContains("Unrecoverable error occurred when creating Eventhub "
                                                          + "Client"), "Expected error hasn't logged in the "
                                   + "EventHubClientClass");

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -35,6 +35,10 @@
         <Bug pattern="REC_CATCH_EXCEPTION"/>
     </Match>
     <Match>
+        <Class name="org.wso2.am.analytics.publisher.client.EventHubClient"/>
+        <Bug pattern="CN_IDIOM_NO_SUPER_CALL"/>
+    </Match>
+    <Match>
         <Class name="org.wso2.am.analytics.publisher.util.BackoffRetryCounter"/>
         <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/apim-analytics-publisher/issues/51 

## Approach
Parallel worker threads were introduced with each having its own EventhubClient and Flusher service. Number of worker threads will be decided by "worker.thread.count" property and by default it will be 1. Each worker thread will perform its own error handling.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
