### PR TITLE
Add support to pass authentication call(HTTPS) of Choreo Analytics via a proxy service

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -32,6 +32,18 @@
             <artifactId>azure-messaging-eventhubs</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-jaxrs</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
@@ -71,6 +83,10 @@
         <dependency>
             <groupId>ua.parser.wso2</groupId>
             <artifactId>ua-parser</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthClient.java
@@ -40,10 +40,10 @@ public class AuthClient {
     public static String getSASToken(String authEndpoint, String token, Map<String, String> properties)
             throws ConnectionRecoverableException, ConnectionUnrecoverableException {
 
-        String proxyEnabled = properties.get(Constants.PROXY_ENABLE);
+        String isProxyEnabled = properties.get(Constants.PROXY_ENABLE);
         DefaultApi defaultApi;
 
-        if (Boolean.parseBoolean(proxyEnabled)) {
+        if (Boolean.parseBoolean(isProxyEnabled)) {
             defaultApi = Feign.builder().client(new OkHttpClient(AuthProxyUtils.getProxyClient(properties)))
                     .encoder(new GsonEncoder())
                     .decoder(new GsonDecoder())

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthProxyUtils.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/auth/AuthProxyUtils.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.auth;
+
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.am.analytics.publisher.util.Constants;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.Map;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Util class to generate http client with proxy configurations
+ */
+public class AuthProxyUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthProxyUtils.class);
+    private static KeyStore trustStore;
+    private static TrustManagerFactory trustManagerFactory;
+    private static final String KEYSTORE_TYPE = "JKS";
+    private static final String PROTOCOL = "TLS";
+    private static final String ALGORITHM = "SunX509";
+
+    public static okhttp3.OkHttpClient getProxyClient(Map<String, String> properties) {
+
+        String proxyHost = properties.get(Constants.PROXY_HOST);
+        String proxyPort = properties.get(Constants.PROXY_PORT);
+        String proxyUsername = properties.get(Constants.PROXY_USERNAME);
+        String proxyPassword = properties.get(Constants.PROXY_PASSWORD);
+
+        OkHttpClient.Builder okHttpClientBuilder;
+        SSLSocketFactory sslSocketFactory = getTrustedSSLSocketFactory(properties);
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+        if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+            throw new IllegalStateException("Unexpected default trust managers:" + Arrays.toString(trustManagers));
+        }
+        okHttpClientBuilder = new okhttp3.OkHttpClient.Builder()
+                .sslSocketFactory(sslSocketFactory, (X509TrustManager) trustManagers[0])
+                .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort))));
+
+        if (StringUtils.isNotEmpty(proxyUsername) && StringUtils.isNotEmpty(proxyPassword)) {
+            Authenticator proxyAuthenticator = (route, response) -> {
+                String credential = Credentials.basic(proxyUsername, proxyPassword);
+                return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+            };
+            okHttpClientBuilder.proxyAuthenticator(proxyAuthenticator);
+        }
+
+        return okHttpClientBuilder.build();
+    }
+
+    private static SSLSocketFactory getTrustedSSLSocketFactory(Map<String, String> configProperties) {
+
+        try {
+            String keyStorePassword = configProperties.get(Constants.KEYSTORE_PASSWORD);
+            String keyStoreLocation = configProperties.get(Constants.KEYSTORE_LOCATION);
+            String trustStorePassword = configProperties.get(Constants.TRUSTSTORE_PASSWORD);
+            String trustStoreLocation = configProperties.get(Constants.TRUSTSTORE_LOCATION);
+
+            KeyStore keyStore = loadKeyStore(keyStoreLocation, keyStorePassword);
+            trustStore = loadTrustStore(trustStoreLocation, trustStorePassword);
+            return initSSLConnection(keyStore, keyStorePassword);
+        } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException | CertificateException
+                | IOException | UnrecoverableKeyException e) {
+            log.error("Error while creating the SSL socket factory", e);
+            return null;
+        }
+    }
+
+    private static SSLSocketFactory initSSLConnection(KeyStore keyStore, String keyStorePassword) throws
+            NoSuchAlgorithmException, UnrecoverableKeyException, KeyStoreException, KeyManagementException {
+
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(ALGORITHM);
+        keyManagerFactory.init(keyStore, keyStorePassword.toCharArray());
+
+        trustManagerFactory = TrustManagerFactory.getInstance(ALGORITHM);
+        trustManagerFactory.init(trustStore);
+
+        SSLContext sslContext = SSLContext.getInstance(PROTOCOL);
+        sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+        SSLContext.setDefault(sslContext);
+        return sslContext.getSocketFactory();
+    }
+
+    private static KeyStore loadKeyStore(String keyStorePath, String ksPassword) throws KeyStoreException,
+            IOException, CertificateException, NoSuchAlgorithmException {
+
+        InputStream fileInputStream = null;
+        try {
+            char[] keypassChar = ksPassword.toCharArray();
+            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+            fileInputStream = new FileInputStream(keyStorePath);
+            keyStore.load(fileInputStream, keypassChar);
+            return keyStore;
+        } finally {
+            if (fileInputStream != null) {
+                fileInputStream.close();
+            }
+        }
+    }
+
+    private static KeyStore loadTrustStore(String trustStorePath, String tsPassword) throws KeyStoreException,
+            IOException, CertificateException, NoSuchAlgorithmException {
+
+        return loadKeyStore(trustStorePath, tsPassword);
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubProducerClientFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/EventHubProducerClientFactory.java
@@ -30,6 +30,7 @@ import org.wso2.am.analytics.publisher.exception.ConnectionUnrecoverableExceptio
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Map;
 
 /**
  * Factory class to create EventHubProducerClient instance.
@@ -37,13 +38,13 @@ import java.net.URLDecoder;
 public class EventHubProducerClientFactory {
     private static final Logger log = LoggerFactory.getLogger(EventHubClient.class);
 
-    public static EventHubProducerClient create(String authEndpoint, String authToken,
-                                                AmqpRetryOptions retryOptions)
+    public static EventHubProducerClient create(String authEndpoint, String authToken, AmqpRetryOptions retryOptions,
+                                                Map<String, String> properties)
             throws ConnectionRecoverableException, ConnectionUnrecoverableException {
-        TokenCredential tokenCredential = new WSO2TokenCredential(authEndpoint, authToken);
+        TokenCredential tokenCredential = new WSO2TokenCredential(authEndpoint, authToken, properties);
         String tempSASToken = null;
         // generate SAS token to get eventhub meta data
-        tempSASToken = getSASToken(authEndpoint, authToken);
+        tempSASToken = getSASToken(authEndpoint, authToken, properties);
 
         String resourceURI = getResourceURI(tempSASToken);
         String fullyQualifiedNamespace = getNamespace(resourceURI);
@@ -54,9 +55,9 @@ public class EventHubProducerClientFactory {
                 .buildProducerClient();
     }
 
-    private static String getSASToken(String authEndpoint, String authToken) throws ConnectionRecoverableException,
-                                                                                    ConnectionUnrecoverableException {
-        return AuthClient.getSASToken(authEndpoint, authToken);
+    private static String getSASToken(String authEndpoint, String authToken, Map<String, String> properties)
+            throws ConnectionRecoverableException, ConnectionUnrecoverableException {
+        return AuthClient.getSASToken(authEndpoint, authToken, properties);
     }
 
     /**

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/WSO2TokenCredential.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/WSO2TokenCredential.java
@@ -33,6 +33,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * WSO2 SAS token refresh implementation for TokenCredential
@@ -41,11 +42,13 @@ class WSO2TokenCredential implements TokenCredential {
     private static final Logger log = LoggerFactory.getLogger(WSO2TokenCredential.class);
     private final String authEndpoint;
     private final String authToken;
+    private final Map<String, String> properties;
     private BackoffRetryCounter backoffRetryCounter;
 
-    public WSO2TokenCredential(String authEndpoint, String authToken) {
+    public WSO2TokenCredential(String authEndpoint, String authToken, Map<String, String> properties) {
         this.authEndpoint = authEndpoint;
         this.authToken = authToken;
+        this.properties = properties;
         backoffRetryCounter = new BackoffRetryCounter();
     }
 
@@ -53,7 +56,7 @@ class WSO2TokenCredential implements TokenCredential {
     public Mono<AccessToken> getToken(TokenRequestContext tokenRequestContext) {
         log.debug("Trying to retrieving a new SAS token.");
         try {
-            String sasToken = AuthClient.getSASToken(this.authEndpoint, this.authToken);
+            String sasToken = AuthClient.getSASToken(this.authEndpoint, this.authToken, this.properties);
             backoffRetryCounter.reset();
             log.debug("New SAS token retrieved.");
             // Using lower duration than actual.

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultAnalyticsMetricReporter.java
@@ -60,7 +60,7 @@ public class DefaultAnalyticsMetricReporter extends AbstractMetricReporter {
         String authToken = properties.get(Constants.AUTH_API_TOKEN);
         String authEndpoint = properties.get(Constants.AUTH_API_URL);
         AmqpRetryOptions retryOptions = createRetryOptions(properties);
-        EventHubClient client = new EventHubClient(authEndpoint, authToken, retryOptions);
+        EventHubClient client = new EventHubClient(authEndpoint, authToken, retryOptions, properties);
         eventQueue = new EventQueue(queueSize, workerThreads, client, flushingDelay);
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -65,6 +65,17 @@ public class Constants {
     public static final String AUTH_API_URL = "auth.api.url";
     public static final String AUTH_API_TOKEN = "auth.api.token";
 
+    //Proxy configs
+    public static final String PROXY_ENABLE = "proxyConfig.enable";
+    public static final String PROXY_HOST = "proxyConfig.host";
+    public static final String PROXY_PORT = "proxyConfig.port";
+    public static final String PROXY_USERNAME = "proxyConfig.username";
+    public static final String PROXY_PASSWORD = "proxyConfig.password";
+    public static final String KEYSTORE_LOCATION = "keystore.location";
+    public static final String KEYSTORE_PASSWORD = "keystore.password";
+    public static final String TRUSTSTORE_LOCATION = "truststore.location";
+    public static final String TRUSTSTORE_PASSWORD = "truststore.password";
+
     //Reporter constants
     public static final String DEFAULT_REPORTER = "default";
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -66,15 +66,15 @@ public class Constants {
     public static final String AUTH_API_TOKEN = "auth.api.token";
 
     //Proxy configs
-    public static final String PROXY_ENABLE = "proxyConfig.enable";
-    public static final String PROXY_HOST = "proxyConfig.host";
-    public static final String PROXY_PORT = "proxyConfig.port";
-    public static final String PROXY_USERNAME = "proxyConfig.username";
-    public static final String PROXY_PASSWORD = "proxyConfig.password";
-    public static final String KEYSTORE_LOCATION = "keystore.location";
-    public static final String KEYSTORE_PASSWORD = "keystore.password";
-    public static final String TRUSTSTORE_LOCATION = "truststore.location";
-    public static final String TRUSTSTORE_PASSWORD = "truststore.password";
+    public static final String PROXY_ENABLE = "proxy_config_enable";
+    public static final String PROXY_HOST = "proxy_config_host";
+    public static final String PROXY_PORT = "proxy_config_port";
+    public static final String PROXY_USERNAME = "proxy_config_username";
+    public static final String PROXY_PASSWORD = "proxy_config_password";
+    public static final String KEYSTORE_LOCATION = "keystore_location";
+    public static final String KEYSTORE_PASSWORD = "keystore_password";
+    public static final String TRUSTSTORE_LOCATION = "truststore_location";
+    public static final String TRUSTSTORE_PASSWORD = "truststore_password";
 
     //Reporter constants
     public static final String DEFAULT_REPORTER = "default";

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/AuthAPIClientTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/AuthAPIClientTestCase.java
@@ -25,6 +25,7 @@ import org.wso2.am.analytics.publisher.exception.ConnectionRecoverableException;
 import org.wso2.am.analytics.publisher.exception.ConnectionUnrecoverableException;
 import org.wso2.am.analytics.publisher.util.AuthAPIMockService;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public class AuthAPIClientTestCase extends AuthAPIMockService {
@@ -37,7 +38,7 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(401, authToken);
 
         String authEndpoint = "http://localhost:1234/auth-api";
-        AuthClient.getSASToken(authEndpoint, authToken);
+        AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
     }
 
     @Test
@@ -47,7 +48,7 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(200, authToken);
 
         String authEndpoint = "http://localhost:1234/auth-api";
-        String sasToken = AuthClient.getSASToken(authEndpoint, authToken);
+        String sasToken = AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
         Assert.assertEquals(sasToken, SAS_TOKEN);
     }
 
@@ -58,7 +59,7 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(500, authToken);
 
         String authEndpoint = "http://localhost:1234/auth-api";
-        AuthClient.getSASToken(authEndpoint, authToken);
+        AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
     }
 
     @Test(expectedExceptions = { ConnectionRecoverableException.class })
@@ -68,7 +69,7 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(400, authToken);
 
         String authEndpoint = "http://localhost:1234/auth-api";
-        AuthClient.getSASToken(authEndpoint, authToken);
+        AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
     }
 
     @Test(expectedExceptions = { ConnectionRecoverableException.class },
@@ -79,7 +80,7 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(403, authToken);
 
         String authEndpoint = "http://localhost:1234/auth-api";
-        AuthClient.getSASToken(authEndpoint, authToken);
+        AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
     }
 
     @Test(expectedExceptions = { ConnectionUnrecoverableException.class },
@@ -90,7 +91,7 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(200, authToken);
 
         String authEndpoint = "invalid/host/auth-api";
-        AuthClient.getSASToken(authEndpoint, authToken);
+        AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
     }
 
     @Test(expectedExceptions = { ConnectionRecoverableException.class },
@@ -101,6 +102,6 @@ public class AuthAPIClientTestCase extends AuthAPIMockService {
         mock(200, authToken);
 
         String authEndpoint = "https://no.such.host/auth-api";
-        AuthClient.getSASToken(authEndpoint, authToken);
+        AuthClient.getSASToken(authEndpoint, authToken, new HashMap<>());
     }
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultChoreoFaultMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultChoreoFaultMetricBuilderTestCase.java
@@ -37,6 +37,7 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DefaultChoreoFaultMetricBuilderTestCase {
@@ -51,7 +52,8 @@ public class DefaultChoreoFaultMetricBuilderTestCase {
                 .setMaxDelay(Duration.ofSeconds(120))
                 .setTryTimeout(Duration.ofSeconds(30))
                 .setMode(AmqpRetryMode.FIXED);
-        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions);
+        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions,
+                new HashMap<>());
         EventQueue queue = new EventQueue(100, 1, client, 10);
         DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue,
                 MetricSchema.CHOREO_ERROR);

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultChoreoResponseMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultChoreoResponseMetricBuilderTestCase.java
@@ -37,6 +37,7 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DefaultChoreoResponseMetricBuilderTestCase {
@@ -52,7 +53,7 @@ public class DefaultChoreoResponseMetricBuilderTestCase {
                 .setMaxDelay(Duration.ofSeconds(120))
                 .setTryTimeout(Duration.ofSeconds(30))
                 .setMode(AmqpRetryMode.FIXED);
-        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions);
+        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions, new HashMap<>());
         EventQueue queue = new EventQueue(100, 1, client, 10);
         DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue,
                 MetricSchema.CHOREO_RESPONSE);

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
@@ -37,6 +37,7 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DefaultFaultMetricBuilderTestCase {
@@ -51,7 +52,8 @@ public class DefaultFaultMetricBuilderTestCase {
                 .setMaxDelay(Duration.ofSeconds(120))
                 .setTryTimeout(Duration.ofSeconds(30))
                 .setMode(AmqpRetryMode.FIXED);
-        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions);
+        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions,
+                new HashMap<>());
         EventQueue queue = new EventQueue(100, 1, client, 10);
         DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue, MetricSchema.ERROR);
         builder = metric.getEventBuilder();

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultResponseMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultResponseMetricBuilderTestCase.java
@@ -37,6 +37,7 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DefaultResponseMetricBuilderTestCase {
@@ -52,7 +53,7 @@ public class DefaultResponseMetricBuilderTestCase {
                 .setMaxDelay(Duration.ofSeconds(120))
                 .setTryTimeout(Duration.ofSeconds(30))
                 .setMode(AmqpRetryMode.FIXED);
-        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions);
+        EventHubClient client = new EventHubClient("some_endpoint", "some_token", retryOptions, new HashMap<>());
         EventQueue queue = new EventQueue(100, 1, client, 10);
         DefaultCounterMetric metric = new DefaultCounterMetric("test.builder.metric", queue, MetricSchema.RESPONSE);
         builder = metric.getEventBuilder();

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -47,6 +47,10 @@
         <Bug pattern="IMPROPER_UNICODE"/>
     </Match>
     <Match>
+        <Class name="org.wso2.am.analytics.publisher.auth.AuthProxyUtils"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+    </Match>
+    <Match>
         <Class name="org.wso2.am.analytics.publisher.util.UserAgentParser$1"/>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
     </Match>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,26 @@
                 <version>${ua_parser.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-okhttp</artifactId>
+                <version>${openfeign.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-jaxrs</artifactId>
+                <version>${openfeign.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp3.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${apache.commons.lang3.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
                 <classifier>runtime</classifier>
@@ -283,6 +303,8 @@
         <ua_parser.version>1.3.0.wso2v2</ua_parser.version>
         <ua_parser.import.version.range>[1.3.0,2)</ua_parser.import.version.range>
         <jacoco.version>0.8.6</jacoco.version>
+        <apache.commons.lang3.version>3.10</apache.commons.lang3.version>
+        <okhttp3.client.version>3.8.1</okhttp3.client.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <mockserver-netty.version>3.10.8</mockserver-netty.version>
     </properties>


### PR DESCRIPTION
## Purpose
Adds $subject. 

If user wants to pass the authentication call of Choreo Analytics via a proxy service, following configuration needs to be added in deployment.toml:

```toml
[apim.analytics.properties]
"proxy_config_enable" = true
"proxy_config_host" = "xxxxxx"
"proxy_config_port" = "xxxx"
"proxy_config_username" = "xxxx"
"proxy_config_password" = "xxxx"
```

Fixes https://github.com/wso2/product-apim/issues/12326

Resources:

- https://github.com/wso2/carbon-device-mgt/blob/b4e8bb4da0fd2f98f597684a582f13927393a31e/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
- https://linuxtut.com/en/e9a78d73836d8692fae7/
- https://github.com/wso2-support/apim-analytics-publisher/compare/v1.0.1.2...janithcmw:feignProxyTryOut