### PR TITLE
Ignoring properties from event map

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultFaultMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultFaultMetricEventBuilder.java
@@ -71,6 +71,8 @@ public class DefaultFaultMetricEventBuilder extends AbstractMetricEventBuilder {
     @Override
     protected Map<String, Object> buildEvent() {
         eventMap.put(Constants.EVENT_TYPE, Constants.FAULT_EVENT_TYPE);
+        // customProperties object is not required and removing
+        eventMap.remove(Constants.PROPERTIES);
         return eventMap;
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
@@ -84,6 +84,8 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
             if (userAgentHeader != null) {
                 setUserAgentProperties(userAgentHeader);
             }
+            // customProperties object is not required and removing
+            eventMap.remove(Constants.PROPERTIES);
             isBuilt = true;
         }
         return eventMap;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -56,6 +56,7 @@ public class Constants {
     public static final String ERROR_TYPE = "errorType";
     public static final String ERROR_CODE = "errorCode";
     public static final String ERROR_MESSAGE = "errorMessage";
+    public static final String PROPERTIES = "properties";
 
     //Builder event types
     public static final String RESPONSE_EVENT_TYPE = "response";


### PR DESCRIPTION
## Purpose
To ignore properties property introduced with https://github.com/wso2-support/carbon-apimgt/pull/5261 from event map in cloud implementation.

## Goals
Fixes: https://github.com/wso2/api-manager/issues/443 not harming existing analytics implementations.

## Approach
Ignored properties in eventMap.

