### PR TITLE
Added required attribute filtering functionality.

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/AbstractMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/AbstractMetricEventBuilder.java
@@ -40,5 +40,5 @@ public abstract class AbstractMetricEventBuilder implements MetricEventBuilder {
      *
      * @return Map representing attributes of Metric Event
      */
-    protected abstract Map<String, Object> buildEvent();
+    protected abstract Map<String, Object> buildEvent() throws MetricReportingException;
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultInputValidator.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultInputValidator.java
@@ -28,36 +28,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.wso2.am.analytics.publisher.util.Constants.API_CREATION;
-import static org.wso2.am.analytics.publisher.util.Constants.API_CREATOR_TENANT_DOMAIN;
-import static org.wso2.am.analytics.publisher.util.Constants.API_ID;
-import static org.wso2.am.analytics.publisher.util.Constants.API_METHOD;
-import static org.wso2.am.analytics.publisher.util.Constants.API_NAME;
-import static org.wso2.am.analytics.publisher.util.Constants.API_RESOURCE_TEMPLATE;
-import static org.wso2.am.analytics.publisher.util.Constants.API_TYPE;
-import static org.wso2.am.analytics.publisher.util.Constants.API_VERSION;
-import static org.wso2.am.analytics.publisher.util.Constants.APPLICATION_ID;
-import static org.wso2.am.analytics.publisher.util.Constants.APPLICATION_NAME;
-import static org.wso2.am.analytics.publisher.util.Constants.APPLICATION_OWNER;
-import static org.wso2.am.analytics.publisher.util.Constants.BACKEND_LATENCY;
-import static org.wso2.am.analytics.publisher.util.Constants.CORRELATION_ID;
-import static org.wso2.am.analytics.publisher.util.Constants.DESTINATION;
-import static org.wso2.am.analytics.publisher.util.Constants.ERROR_CODE;
-import static org.wso2.am.analytics.publisher.util.Constants.ERROR_MESSAGE;
-import static org.wso2.am.analytics.publisher.util.Constants.ERROR_TYPE;
-import static org.wso2.am.analytics.publisher.util.Constants.GATEWAY_TYPE;
-import static org.wso2.am.analytics.publisher.util.Constants.KEY_TYPE;
-import static org.wso2.am.analytics.publisher.util.Constants.ORGANIZATION_ID;
-import static org.wso2.am.analytics.publisher.util.Constants.PROXY_RESPONSE_CODE;
-import static org.wso2.am.analytics.publisher.util.Constants.REGION_ID;
-import static org.wso2.am.analytics.publisher.util.Constants.REQUEST_MEDIATION_LATENCY;
-import static org.wso2.am.analytics.publisher.util.Constants.REQUEST_TIMESTAMP;
-import static org.wso2.am.analytics.publisher.util.Constants.RESPONSE_CACHE_HIT;
-import static org.wso2.am.analytics.publisher.util.Constants.RESPONSE_LATENCY;
-import static org.wso2.am.analytics.publisher.util.Constants.RESPONSE_MEDIATION_LATENCY;
-import static org.wso2.am.analytics.publisher.util.Constants.TARGET_RESPONSE_CODE;
-import static org.wso2.am.analytics.publisher.util.Constants.USER_AGENT_HEADER;
-import static org.wso2.am.analytics.publisher.util.Constants.USER_IP;
+import static org.wso2.am.analytics.publisher.util.Constants.*;
 
 /**
  * Input Validator for {@link DefaultAnalyticsMetricReporter}. Validator holds all required attributes against which
@@ -75,6 +46,7 @@ public class DefaultInputValidator {
             new AbstractMap.SimpleImmutableEntry<>(API_VERSION, String.class),
             new AbstractMap.SimpleImmutableEntry<>(API_CREATION, String.class),
             new AbstractMap.SimpleImmutableEntry<>(API_METHOD, String.class),
+            new AbstractMap.SimpleImmutableEntry<>(API_CONTEXT, String.class),
             new AbstractMap.SimpleImmutableEntry<>(API_RESOURCE_TEMPLATE, String.class),
             new AbstractMap.SimpleImmutableEntry<>(API_CREATOR_TENANT_DOMAIN, String.class),
             new AbstractMap.SimpleImmutableEntry<>(DESTINATION, String.class),
@@ -84,6 +56,7 @@ public class DefaultInputValidator {
             new AbstractMap.SimpleImmutableEntry<>(REGION_ID, String.class),
             new AbstractMap.SimpleImmutableEntry<>(GATEWAY_TYPE, String.class),
             new AbstractMap.SimpleImmutableEntry<>(USER_AGENT_HEADER, String.class),
+            new AbstractMap.SimpleImmutableEntry<>(USER_NAME, String.class),
             new AbstractMap.SimpleImmutableEntry<>(PROXY_RESPONSE_CODE, Integer.class),
             new AbstractMap.SimpleImmutableEntry<>(TARGET_RESPONSE_CODE, Integer.class),
             new AbstractMap.SimpleImmutableEntry<>(RESPONSE_CACHE_HIT, Boolean.class),

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/EventMapAttributeFilter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/EventMapAttributeFilter.java
@@ -1,0 +1,45 @@
+package org.wso2.am.analytics.publisher.util;
+
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class EventMapAttributeFilter {
+    private static  final EventMapAttributeFilter INSTANCE = new EventMapAttributeFilter();
+
+    public static EventMapAttributeFilter getInstance(){
+        return INSTANCE;
+    }
+
+    public Map<String,Object> filter(Map<String,Object> source, Map<String,Class> requiredAttributes) throws  MetricReportingException{
+
+        Set<String> targetKeys = requiredAttributes.keySet();
+        Map<String,Object> filteredEventMap = new HashMap<>();
+        if(validateRequiredAttributes(source,requiredAttributes)) {
+            for (String key : targetKeys) {
+                filteredEventMap.put(key, source.get(key));
+            }
+        }
+
+        return filteredEventMap;
+    }
+
+    private static boolean validateRequiredAttributes(Map<String,Object> source, Map<String,Class> requiredAttributes) throws MetricReportingException {
+
+        for (Map.Entry<String, Class> entry : requiredAttributes.entrySet()) {
+            Object attribute = source.get(entry.getKey());
+            if (attribute == null) {
+                throw new MetricReportingException(entry.getKey() + " is set as required attribute but missing in metric data. This metric event "
+                        + "will not be processed further.");
+            } else if (!attribute.getClass().equals(entry.getValue())) {
+                throw new MetricReportingException(entry.getKey() + " is expecting a " + entry.getValue() + " type "
+                        + "required attribute while attribute of type "
+                        + attribute.getClass() + " is present.");
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
## Purpose
EventBuilder should be able to filter required attributes defined by it.

## Goals
In cases where some event metrics included in default metric schema are not required, by this modification one can pass custom metric schema to filter out only the required attributes defined in the custom schema.  

## Approach
Added user name and api context in the default schema.
Modified the implementation such that one can define required attributes/ custom schema and pass it to the event builder.
Added util functionality to validate required attribute & then filter out. 

## User stories
By default event metrics include user name. But it is necessary to filter out user name in cases where the event metrics are published to Choreo Insights.

## Automation tests
 - Unit tests : No
 - Integration tests: No

## Test environment
JDK 11.0.16
Ubuntu 22.04.1 LTS