### PR TITLE
New Reporter for Moesif API analytics dashboard.

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -103,6 +103,21 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.moesif.api</groupId>
+            <artifactId>moesifapi</artifactId>
+            <version>1.6.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -106,17 +106,6 @@
         <dependency>
             <groupId>com.moesif.api</groupId>
             <artifactId>moesifapi</artifactId>
-            <version>1.6.17</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.9</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.cdimascio</groupId>
-            <artifactId>dotenv-java</artifactId>
-            <version>2.3.1</version>
         </dependency>
     </dependencies>
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -84,7 +84,7 @@ public class MoesifClient {
     /**
      * publish method is responsible for checking the availability of relevant moesif key
      * and initiating moesif client sdk.
-    */
+     */
     public void publish(Map<String, Object> event) throws MetricReportingException {
         ConcurrentHashMap<String, String> orgIDMoesifKeyMap = keyRetriever.getMoesifKeyMap();
         if (orgIDMoesifKeyMap.isEmpty()) {
@@ -126,9 +126,9 @@ public class MoesifClient {
                 if (statusCode >= 400 && statusCode < 500) {
                     log.error("Event publishing failed. Moesif returned " + statusCode);
                 } else if (error != null) {
-                    log.error("Event publishing failed." + error.getMessage());
+                    log.error("Event publishing failed." + error);
                 } else {
-                    log.error("Event publishing failed.Retrying.");
+                    log.error("Event publishing failed. Retrying.");
                     doRetry(orgId, event);
                 }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -124,9 +124,9 @@ public class MoesifClient {
                 int statusCode = context.getResponse().getStatusCode();
 
                 if (statusCode >= 400 && statusCode < 500) {
-                    log.error("Event publishing failed. Moesif returned " + statusCode);
+                    log.error("Event publishing failed. Moesif returned:", statusCode);
                 } else if (error != null) {
-                    log.error("Event publishing failed." + error);
+                    log.error("Event publishing failed.", error);
                 } else {
                     log.error("Event publishing failed. Retrying.");
                     doRetry(orgId, event);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.client;
+
+import com.google.gson.Gson;
+import com.moesif.api.MoesifAPIClient;
+import com.moesif.api.controllers.APIController;
+import com.moesif.api.http.client.APICallBack;
+import com.moesif.api.http.client.HttpContext;
+import com.moesif.api.http.response.HttpResponse;
+import com.moesif.api.models.EventBuilder;
+import com.moesif.api.models.EventModel;
+import com.moesif.api.models.EventRequestBuilder;
+import com.moesif.api.models.EventRequestModel;
+import com.moesif.api.models.EventResponseBuilder;
+import com.moesif.api.models.EventResponseModel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifMicroserviceConstants;
+import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
+import org.wso2.am.analytics.publisher.util.Constants;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Moesif Client is responsible for sending events to
+ * Moesif Analytics Dashboard.
+ */
+public class MoesifClient {
+    private final Logger log = LoggerFactory.getLogger(MoesifClient.class);
+    private final MoesifKeyRetriever keyRetriever;
+
+    public MoesifClient(MoesifKeyRetriever keyRetriever) {
+        this.keyRetriever = keyRetriever;
+    }
+
+    private void doRetry(String orgId, Map<String, Object> event) {
+        Integer currentAttempt = MoesifClientContextHolder.publishAttempts.get();
+
+        if (currentAttempt > 0) {
+            if (currentAttempt == MoesifMicroserviceConstants.NUM_RETRY_ATTEMPTS_PUBLISH) {
+                // on failure remove the respective moesif key from the map.
+                // this will result in a call to the microservice to retrieve the key.
+                // This is enough to happen only at the first attempt.
+                keyRetriever.removeMoesifKeyFromMap(orgId);
+            }
+            currentAttempt -= 1;
+            MoesifClientContextHolder.publishAttempts.set(currentAttempt);
+            try {
+                Thread.sleep(MoesifMicroserviceConstants.TIME_TO_WAIT_PUBLISH);
+                publish(event);
+            } catch (MetricReportingException e) {
+                log.error("Failing retry attempt at Moesif client", e);
+            } catch (InterruptedException e) {
+                log.error("Failing retry attempt at Moesif client", e);
+            }
+        } else if (currentAttempt == 0) {
+            log.error("Failed all retrying attempts. Event will be dropped");
+        }
+    }
+
+    /**
+     * publish method is responsible for checking the availability of relevant moesif key
+     * and initiating moesif client sdk.
+    */
+    public void publish(Map<String, Object> event) throws MetricReportingException {
+        ConcurrentHashMap<String, String> orgIDMoesifKeyMap = keyRetriever.getMoesifKeyMap();
+        if (orgIDMoesifKeyMap.isEmpty()) {
+            keyRetriever.initOrRefreshOrgIDMoesifKeyMap();
+        }
+
+        String orgId = (String) event.get(Constants.ORGANIZATION_ID);
+        String moesifKey;
+        if (orgIDMoesifKeyMap.containsKey(orgId)) {
+            moesifKey = orgIDMoesifKeyMap.get(orgId);
+        } else {
+            moesifKey = keyRetriever.getMoesifKey(orgId);
+            if (moesifKey == null) {
+                throw new MetricReportingException(
+                        "Corresponding Moesif key for organization " + orgId + " can't be found.");
+            }
+        }
+
+        // init moesif api client
+        MoesifAPIClient client = keyRetriever.getMoesifClient(moesifKey);
+        APIController api = client.getAPI();
+
+        APICallBack<HttpResponse> callBack = new APICallBack<HttpResponse>() {
+            public void onSuccess(HttpContext context, HttpResponse response) {
+                int statusCode = context.getResponse().getStatusCode();
+                if (statusCode == 200) {
+                    log.debug("Event successfully published.");
+                } else if (statusCode >= 400 && statusCode < 500) {
+                    log.error("Event publishing failed. Moesif returned " + statusCode);
+                } else {
+                    log.error("Event publishing failed.Retrying.");
+                    doRetry(orgId, event);
+                }
+            }
+
+            public void onFailure(HttpContext context, Throwable error) {
+                int statusCode = context.getResponse().getStatusCode();
+
+                if (statusCode >= 400 && statusCode < 500) {
+                    log.error("Event publishing failed. Moesif returned " + statusCode);
+                } else if (error != null) {
+                    log.error("Event publishing failed." + error.getMessage());
+                } else {
+                    log.error("Event publishing failed.Retrying.");
+                    doRetry(orgId, event);
+                }
+
+            }
+        };
+        try {
+            api.createEventAsync(buildEventResponse(event), callBack);
+        } catch (IOException e) {
+            log.error("Analytics event sending failed. Event will be dropped", e);
+        }
+
+    }
+
+    private EventModel buildEventResponse(Map<String, Object> data) throws IOException, MetricReportingException {
+        Gson gson = new Gson();
+        String jsonString = gson.toJson(data);
+        String reqBody = jsonString.replaceAll("[\r\n]", "");
+
+        //      Preprocessing data
+        final URL uri = new URL((String) data.get(Constants.DESTINATION));
+        final String hostName = uri.getHost();
+
+        final String userIP = (String) data.get(Constants.USER_IP);
+
+        Map<String, String> reqHeaders = new HashMap<String, String>();
+
+        reqHeaders.put("User-Agent",
+                (String) data.getOrDefault(Constants.USER_AGENT_HEADER, Constants.UNKNOWN_VALUE));
+        reqHeaders.put("Content-Type", Constants.MOESIF_CONTENT_TYPE_HEADER);
+        reqHeaders.put("Host", hostName);
+
+        Map<String, String> rspHeaders = new HashMap<String, String>();
+
+        rspHeaders.put("Vary", "Accept-Encoding");
+        rspHeaders.put("Pragma", "no-cache");
+        rspHeaders.put("Expires", "-1");
+        rspHeaders.put("Content-Type", "application/json; charset=utf-8");
+        rspHeaders.put("Cache-Control", "no-cache");
+
+
+        EventRequestModel eventReq = new EventRequestBuilder()
+                .time(new Date()) // See if you can parse request time stamp to date obj
+                .uri(uri.toString())
+                .verb((String) data.get(Constants.API_METHOD))
+                .apiVersion((String) data.get(Constants.API_VERSION))
+                .ipAddress(userIP)
+                .headers(reqHeaders)
+                .body(reqBody)
+                .build();
+
+
+        EventResponseModel eventRsp = new EventResponseBuilder()
+                .time(new Date(System.currentTimeMillis() + 1000))
+                .status((int) data.get(Constants.TARGET_RESPONSE_CODE))
+                .headers(rspHeaders)
+                .build();
+
+        EventModel eventModel = new EventBuilder()
+                .request(eventReq)
+                .response(eventRsp)
+                .userId((String) data.get("userName"))
+                .companyId((String) data.get(Constants.ORGANIZATION_ID))
+                .build();
+
+        return eventModel;
+    }
+
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -57,7 +57,7 @@ public class MoesifClient {
     }
 
     private void doRetry(String orgId, Map<String, Object> event) {
-        Integer currentAttempt = MoesifClientContextHolder.publishAttempts.get();
+        Integer currentAttempt = MoesifClientContextHolder.PUBLISH_ATTEMPTS.get();
 
         if (currentAttempt > 0) {
             if (currentAttempt == MoesifMicroserviceConstants.NUM_RETRY_ATTEMPTS_PUBLISH) {
@@ -67,7 +67,7 @@ public class MoesifClient {
                 keyRetriever.removeMoesifKeyFromMap(orgId);
             }
             currentAttempt -= 1;
-            MoesifClientContextHolder.publishAttempts.set(currentAttempt);
+            MoesifClientContextHolder.PUBLISH_ATTEMPTS.set(currentAttempt);
             try {
                 Thread.sleep(MoesifMicroserviceConstants.TIME_TO_WAIT_PUBLISH);
                 publish(event);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClientContextHolder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClientContextHolder.java
@@ -21,7 +21,7 @@ package org.wso2.am.analytics.publisher.client;
  * Holds context of the Moesif client retry mechanism.
  */
 public class MoesifClientContextHolder {
-    public static ThreadLocal<Integer> publishAttempts = new ThreadLocal<Integer>() {
+    public static final ThreadLocal<Integer> PUBLISH_ATTEMPTS = new ThreadLocal<Integer>() {
         @Override
         protected Integer initialValue() {
             return new Integer(1);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClientContextHolder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClientContextHolder.java
@@ -24,7 +24,7 @@ public class MoesifClientContextHolder {
     public static final ThreadLocal<Integer> PUBLISH_ATTEMPTS = new ThreadLocal<Integer>() {
         @Override
         protected Integer initialValue() {
-            return new Integer(1);
+            return Integer.valueOf(1);
         }
 
         @Override

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClientContextHolder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClientContextHolder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.client;
+
+/**
+ * Holds context of the Moesif client retry mechanism.
+ */
+public class MoesifClientContextHolder {
+    public static ThreadLocal<Integer> publishAttempts = new ThreadLocal<Integer>() {
+        @Override
+        protected Integer initialValue() {
+            return new Integer(1);
+        }
+
+        @Override
+        public Integer get() {
+            return super.get();
+        }
+
+        @Override
+        public void set(Integer value) {
+            super.set(value);
+        }
+    };
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/APICallException.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/APICallException.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.am.analytics.publisher.exception;
 
 /**

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/APICallException.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/exception/APICallException.java
@@ -1,0 +1,15 @@
+package org.wso2.am.analytics.publisher.exception;
+
+/**
+ * Exception class for API calls related exceptions.
+ * Could be used in scenarios where the issue is not strictly due to HTTP Client.
+ */
+public class APICallException extends Exception {
+    public APICallException(String msg) {
+        super(msg);
+    }
+
+    public APICallException(String msg, Throwable e) {
+        super(msg, e);
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsThreadFactory;
+import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Bounded concurrent queue wrapping for Moesif reporter{@link java.util.concurrent.ArrayBlockingQueue}.
+ */
+public class EventQueue {
+    private static final Logger log = LoggerFactory.getLogger(EventQueue.class);
+    private final BlockingQueue<MetricEventBuilder> eventQueue;
+    private final ExecutorService publisherExecutorService;
+    private final AtomicInteger failureCount;
+    private final MoesifKeyRetriever moesifKeyRetriever;
+
+    public EventQueue(int queueSize, int workerThreadCount, MoesifKeyRetriever moesifKeyRetriever) {
+        this.moesifKeyRetriever = moesifKeyRetriever;
+
+        publisherExecutorService = Executors.newFixedThreadPool(workerThreadCount,
+                new DefaultAnalyticsThreadFactory("Queue-Worker"));
+        eventQueue = new LinkedBlockingQueue<>(queueSize);
+        failureCount = new AtomicInteger(0);
+        for (int i = 0; i < workerThreadCount; i++) {
+            publisherExecutorService.submit(new ParallelQueueWorker(eventQueue, moesifKeyRetriever));
+        }
+    }
+
+    public void put(MetricEventBuilder builder) {
+        try {
+            if (!eventQueue.offer(builder)) {
+                int count = failureCount.incrementAndGet();
+                if (count == 1) {
+                    log.error("Event queue is full. Starting to drop analytics events.");
+                } else if (count % 1000 == 0) {
+                    log.error("Event queue is full. " + count + " events dropped so far");
+                }
+            }
+        } catch (RejectedExecutionException e) {
+            log.warn("Task submission failed. Task queue might be full", e);
+        }
+
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        publisherExecutorService.shutdown();
+        super.finalize();
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
@@ -48,8 +48,7 @@ public class EventQueue {
         eventQueue = new LinkedBlockingQueue<>(queueSize);
         failureCount = new AtomicInteger(0);
         for (int i = 0; i < workerThreadCount; i++) {
-            ExecutorService executorService = (ExecutorService) publisherExecutorService.submit(
-                    new ParallelQueueWorker(eventQueue, moesifKeyRetriever));
+            publisherExecutorService.submit(new ParallelQueueWorker(eventQueue, moesifKeyRetriever));
         }
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
@@ -48,7 +48,8 @@ public class EventQueue {
         eventQueue = new LinkedBlockingQueue<>(queueSize);
         failureCount = new AtomicInteger(0);
         for (int i = 0; i < workerThreadCount; i++) {
-            publisherExecutorService.submit(new ParallelQueueWorker(eventQueue, moesifKeyRetriever));
+            ExecutorService executorService = (ExecutorService) publisherExecutorService.submit(
+                    new ParallelQueueWorker(eventQueue, moesifKeyRetriever));
         }
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifCounterMetric.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.GenericInputValidator;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+
+/**
+ * Implementation of {@link CounterMetric} for Moesif Metric Reporter.
+ */
+public class MoesifCounterMetric implements CounterMetric {
+    private static final Logger log = LoggerFactory.getLogger(MoesifCounterMetric.class);
+    private String name;
+    private MetricSchema schema;
+    private EventQueue queue;
+
+
+    public MoesifCounterMetric(String name, EventQueue queue, MetricSchema schema) {
+        this.name = name;
+        this.schema = schema;
+        this.queue = queue;
+    }
+
+    @Override
+    public int incrementCount(MetricEventBuilder metricEventBuilder) throws MetricReportingException {
+        queue.put(metricEventBuilder);
+        return 0;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public MetricSchema getSchema() {
+        return this.schema;
+    }
+
+    /**
+     * Returns Event Builder used for this CounterMetric. Depending on the schema different types of builders will be
+     * returned.
+     *
+     * @return {@link MetricEventBuilder} for this {@link CounterMetric}
+     */
+    @Override
+    public MetricEventBuilder getEventBuilder() {
+        switch (schema) {
+            case RESPONSE:
+            default:
+                return new MoesifMetricEventBuilder(
+                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.RESPONSE));
+            case ERROR:
+                return new MoesifMetricEventBuilder(
+                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.ERROR));
+            case CHOREO_RESPONSE:
+                return new MoesifMetricEventBuilder(
+                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.CHOREO_RESPONSE));
+            case CHOREO_ERROR:
+                return new MoesifMetricEventBuilder(
+                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.CHOREO_ERROR));
+        }
+    }
+
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifMetricEventBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif;
+
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.AbstractMetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.GenericInputValidator;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.am.analytics.publisher.util.EventMapAttributeFilter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Event builder for Moesif Metric Reporter. Default Event builder has response schema type.
+ */
+public class MoesifMetricEventBuilder extends AbstractMetricEventBuilder {
+    protected Map<String, Class> requiredAttributes;
+    private Map<String, Object> eventMap;
+    private Boolean isBuilt = false;
+
+    public MoesifMetricEventBuilder() {
+        requiredAttributes = GenericInputValidator.getInstance().getEventProperties(MetricSchema.RESPONSE);
+        eventMap = new HashMap<>();
+    }
+
+    public MoesifMetricEventBuilder(Map<String, Class> requiredAttributes) {
+        this.requiredAttributes = requiredAttributes;
+        eventMap = new HashMap<>();
+    }
+
+    @Override
+    protected Map<String, Object> buildEvent() {
+        if (!isBuilt) {
+            // util function to filter required attributes
+            eventMap = EventMapAttributeFilter.getInstance().filter(eventMap, requiredAttributes);
+
+            isBuilt = true;
+        }
+        return eventMap;
+    }
+
+    @Override
+    public boolean validate() throws MetricReportingException {
+        if (!isBuilt) {
+            for (Map.Entry<String, Class> entry : requiredAttributes.entrySet()) {
+                Object attribute = eventMap.get(entry.getKey());
+                if (attribute == null) {
+                    throw new MetricReportingException(entry.getKey() + " is missing in metric data. This metric event "
+                            + "will not be processed further.");
+                } else if (!attribute.getClass().equals(entry.getValue())) {
+                    throw new MetricReportingException(entry.getKey() + " is expecting a " + entry.getValue() + " type "
+                            + "attribute while attribute of type "
+                            + attribute.getClass() + " is present.");
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public MetricEventBuilder addAttribute(String key, Object value) throws MetricReportingException {
+        eventMap.put(key, value);
+        return this;
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.am.analytics.publisher.exception.MetricCreationException;
+import org.wso2.am.analytics.publisher.reporter.AbstractMetricReporter;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.am.analytics.publisher.reporter.TimerMetric;
+import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifMicroserviceConstants;
+import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
+import org.wso2.am.analytics.publisher.util.Constants;
+
+import java.util.Map;
+
+/**
+ * Moesif Metric Reporter Implementation. This implementation is responsible for sending analytics data into Moesif
+ * dashboard in a secure and reliable way.
+ */
+public class MoesifReporter extends AbstractMetricReporter {
+    private static final Logger log = LoggerFactory.getLogger(MoesifReporter.class);
+    private final Map<String, String> properties;
+    private final EventQueue eventQueue;
+
+    public MoesifReporter(Map<String, String> properties) throws MetricCreationException {
+        super(properties);
+        this.properties = properties;
+        MoesifKeyRetriever keyRetriever =
+                MoesifKeyRetriever.getInstance(properties.get(MoesifMicroserviceConstants.GA_USERNAME_CONFIG_KEY),
+                        properties.get(MoesifMicroserviceConstants.GA_PWD_CONFIG_KEY));
+        int queueSize = Constants.DEFAULT_QUEUE_SIZE;
+        int workerThreads = Constants.DEFAULT_WORKER_THREADS;
+        if (properties.get(Constants.QUEUE_SIZE) != null) {
+            queueSize = Integer.parseInt(properties.get(Constants.QUEUE_SIZE));
+        }
+        if (properties.get(Constants.WORKER_THREAD_COUNT) != null) {
+            workerThreads = Integer.parseInt(properties.get(Constants.WORKER_THREAD_COUNT));
+        }
+        eventQueue = new EventQueue(queueSize, workerThreads, keyRetriever);
+    }
+
+    @Override
+    protected void validateConfigProperties(Map<String, String> map) throws MetricCreationException {
+
+    }
+
+    @Override
+    public CounterMetric createCounter(String name, MetricSchema metricSchema) throws MetricCreationException {
+        MoesifCounterMetric logCounterMetric = new MoesifCounterMetric(name, eventQueue, metricSchema);
+
+        return logCounterMetric;
+    }
+
+    @Override
+    protected TimerMetric createTimer(String s) {
+        return null;
+    }
+}
+

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/ParallelQueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/ParallelQueueWorker.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.wso2.am.analytics.publisher.client.MoesifClient;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
+
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Will dequeue the events from queues and send then to the moesif client {@link MoesifClient}.
+ */
+public class ParallelQueueWorker implements Runnable {
+    private  static  final Logger log = LoggerFactory.getLogger(ParallelQueueWorker.class);
+    private BlockingQueue<MetricEventBuilder> eventQueue;
+    private MoesifKeyRetriever keyRetriever;
+
+
+    public ParallelQueueWorker(BlockingQueue<MetricEventBuilder> queue, MoesifKeyRetriever keyRetriever) {
+        this.eventQueue = queue;
+        this.keyRetriever = keyRetriever;
+    }
+
+    public void run() {
+
+        while (true) {
+            MetricEventBuilder eventBuilder;
+            try {
+                eventBuilder = eventQueue.take();
+                if (eventBuilder != null) {
+                    MoesifClient client = new MoesifClient(keyRetriever);
+                    Map<String, Object> eventMap = eventBuilder.build();
+                    client.publish(eventMap);
+                }
+            } catch (MetricReportingException e) {
+                log.error("Builder instance is not duly filled. Event building failed", e);
+                continue;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.error("Analytics event sending failed. Event will be dropped", e);
+            }
+
+        }
+    }
+
+
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifKeyEntry.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifKeyEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif.util;
+
+/**
+ * POJO to parse the JSON.
+ */
+public class MoesifKeyEntry {
+    private String uuid;
+    private String organization_id;
+    private String moesif_key;
+    private String env;
+
+    public MoesifKeyEntry() {
+
+    }
+
+    public String getMoesif_key() {
+        return moesif_key;
+    }
+
+    public String getOrganization_id() {
+        return organization_id;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public String getEnv() {
+        return env;
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifKeyEntry.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifKeyEntry.java
@@ -17,13 +17,17 @@
  */
 package org.wso2.am.analytics.publisher.reporter.moesif.util;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * POJO to parse the JSON.
  */
 public class MoesifKeyEntry {
     private String uuid;
-    private String organization_id;
-    private String moesif_key;
+    @SerializedName("organization_id")
+    private String organizationID;
+    @SerializedName("moesif_key")
+    private String moesifKey;
     private String env;
 
     public MoesifKeyEntry() {
@@ -31,11 +35,11 @@ public class MoesifKeyEntry {
     }
 
     public String getMoesif_key() {
-        return moesif_key;
+        return moesifKey;
     }
 
     public String getOrganization_id() {
-        return organization_id;
+        return organizationID;
     }
 
     public String getUuid() {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifMicroserviceConstants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifMicroserviceConstants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.reporter.moesif.util;
+
+/**
+ * Class for constants related to external Moesif microservice.
+ */
+public class MoesifMicroserviceConstants {
+    public static final String DETAIL_URL = "http://microservice:port/moesif_key/";
+    public static final String LIST_URL = "http://microservice:port/moesif_key";
+    public static final String GA_USERNAME_CONFIG_KEY = "gaAuthUsername";
+    public static final String GA_PWD_CONFIG_KEY = "gaAuthPwd";
+    public static final String CONTENT_TYPE = "application/json";
+    public static final String QUERY_PARAM = "org_id";
+    public static final int NUM_RETRY_ATTEMPTS = 3;
+    public static final long TIME_TO_WAIT = 10000;
+    public static final int NUM_RETRY_ATTEMPTS_PUBLISH = 3;
+    public static final long TIME_TO_WAIT_PUBLISH = 10000;
+    public static final int REQUEST_READ_TIMEOUT = 10000;
+
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifMicroserviceConstants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifMicroserviceConstants.java
@@ -23,6 +23,7 @@ package org.wso2.am.analytics.publisher.reporter.moesif.util;
 public class MoesifMicroserviceConstants {
     public static final String DETAIL_URL = "http://microservice:port/moesif_key/";
     public static final String LIST_URL = "http://microservice:port/moesif_key";
+    public static final String DETAIL_URL_WITH_QUERY = "http://microservice:port/moesif_key/?org_id=";
     public static final String GA_USERNAME_CONFIG_KEY = "gaAuthUsername";
     public static final String GA_PWD_CONFIG_KEY = "gaAuthPwd";
     public static final String CONTENT_TYPE = "application/json";

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -261,7 +261,7 @@ public class MoesifKeyRetriever {
         Gson gson = new Gson();
         String json = response;
 
-        Type collectionType = new innerTypeToken<Collection<MoesifKeyEntry>>().getType();
+        Type collectionType = new InnerTypeToken<Collection<MoesifKeyEntry>>().getType();
         Collection<MoesifKeyEntry> newKeys = gson.fromJson(json, collectionType);
 
         for (MoesifKeyEntry entry : newKeys) {
@@ -291,7 +291,12 @@ public class MoesifKeyRetriever {
         return moesifKeyClientMap.get(moesifKey);
     }
 
-    static class innerTypeToken<T> extends TypeToken<T> {
+    /**
+     * Named inner class for TypeToken protected class.
+     *
+     * @param <T>
+     */
+    static class InnerTypeToken<T> extends TypeToken<T> {
 
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -142,7 +142,7 @@ public class MoesifKeyRetriever {
     }
 
     private void callListResource() throws IOException, APICallException {
-        URL obj;
+        final URL obj;
         String[] urlWhiteArr = {"example.com", "www.example.com"};
         List<String> urlWhiteList = Arrays.asList(urlWhiteArr);
 
@@ -194,9 +194,8 @@ public class MoesifKeyRetriever {
 
     private String callDetailResource(String orgID) throws IOException, APICallException {
         StringBuffer response = new StringBuffer();
-        String url = MoesifMicroserviceConstants.DETAIL_URL + "?" + MoesifMicroserviceConstants.QUERY_PARAM + "=" +
-                orgID;
-        URL obj;
+        final String url = MoesifMicroserviceConstants.DETAIL_URL_WITH_QUERY + orgID;
+        final URL obj;
         String[] urlWhiteArr = {"example.com", "www.example.com"};
         List<String> urlWhiteList = Arrays.asList(urlWhiteArr);
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -51,12 +51,12 @@ public class MoesifKeyRetriever {
 
     private ConcurrentHashMap<String, MoesifAPIClient> moesifKeyClientMap;
     private String gaAuthUsername;
-    private char[] gaAuthPwd;
+    private String gaAuthPwd;
 
     private MoesifKeyRetriever(String authUsername, String authPwd) {
 
         this.gaAuthUsername = authUsername;
-        this.gaAuthPwd = authPwd.toCharArray();
+        this.gaAuthPwd = authPwd;
         orgIDMoesifKeyMap = new ConcurrentHashMap();
         moesifKeyClientMap = new ConcurrentHashMap();
     }
@@ -97,6 +97,7 @@ public class MoesifKeyRetriever {
 
     /**
      * Will retrieve single Moesif key corresponding to given organization ID.
+     *
      * @param orgID
      * @return Moesif Key corresponding orgID
      */
@@ -130,6 +131,7 @@ public class MoesifKeyRetriever {
     /**
      * Will remove Moesif key corresponding to organization ID.
      * Existing Moesif SDK client associated with the moesif key will be also removed.
+     *
      * @param orgID
      */
     public void removeMoesifKeyFromMap(String orgID) {
@@ -145,7 +147,7 @@ public class MoesifKeyRetriever {
             log.error("Event will be dropped. Getting " + ex);
             return;
         }
-        String auth = gaAuthUsername + ":" + gaAuthPwd.toString();
+        String auth = gaAuthUsername + ":" + gaAuthPwd;
         String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
         String authHeaderValue = "Basic " + encodedAuth;
 
@@ -156,7 +158,7 @@ public class MoesifKeyRetriever {
         con.setReadTimeout(MoesifMicroserviceConstants.REQUEST_READ_TIMEOUT);
         int responseCode = con.getResponseCode();
         if (responseCode == HttpsURLConnection.HTTP_OK) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8"));
             String inputLine;
             StringBuffer response = new StringBuffer();
 
@@ -188,7 +190,7 @@ public class MoesifKeyRetriever {
             log.error("Event will be dropped. Getting " + ex);
             return null;
         }
-        String auth = gaAuthUsername + ":" + gaAuthPwd.toString();
+        String auth = gaAuthUsername + ":" + gaAuthPwd;
         String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
         String authHeaderValue = "Basic " + encodedAuth;
 
@@ -199,7 +201,7 @@ public class MoesifKeyRetriever {
         con.setReadTimeout(MoesifMicroserviceConstants.REQUEST_READ_TIMEOUT);
         int responseCode = con.getResponseCode();
         if (responseCode == HttpsURLConnection.HTTP_OK) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8"));
             String inputLine;
 
             while ((inputLine = in.readLine()) != null) {
@@ -247,6 +249,7 @@ public class MoesifKeyRetriever {
 
     /**
      * returning orgID-MoesifKey map.
+     *
      * @return
      */
     public ConcurrentHashMap<String, String> getMoesifKeyMap() {
@@ -255,6 +258,7 @@ public class MoesifKeyRetriever {
 
     /**
      * returning Moesif SDK client associated with the given Moesif key.
+     *
      * @param moesifKey
      * @return
      */

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.retriever;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.moesif.api.MoesifAPIClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.am.analytics.publisher.exception.APICallException;
+import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifKeyEntry;
+import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifMicroserviceConstants;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Responsible for calling the Moesif microservice and refresh/init entire internal map(organization, moesif key) or
+ * retrieving single moesif key.
+ * Also ease Moesif SDK client initiation by maintaining a map(moesif key, moesif sdk client {@link MoesifAPIClient}).
+ */
+public class MoesifKeyRetriever {
+    private static final Logger log = LoggerFactory.getLogger(MoesifKeyRetriever.class);
+    private static MoesifKeyRetriever moesifKeyRetriever;
+    private ConcurrentHashMap<String, String> orgIDMoesifKeyMap;
+
+    private ConcurrentHashMap<String, MoesifAPIClient> moesifKeyClientMap;
+    private String gaAuthUsername;
+    private char[] gaAuthPwd;
+
+    private MoesifKeyRetriever(String authUsername, String authPwd) {
+
+        this.gaAuthUsername = authUsername;
+        this.gaAuthPwd = authPwd.toCharArray();
+        orgIDMoesifKeyMap = new ConcurrentHashMap();
+        moesifKeyClientMap = new ConcurrentHashMap();
+    }
+
+    public static synchronized MoesifKeyRetriever getInstance(String authUsername, String authPwd) {
+        if (moesifKeyRetriever == null) {
+            return new MoesifKeyRetriever(authUsername, authPwd);
+        }
+        return moesifKeyRetriever;
+    }
+
+    /**
+     * Will initialize the empty orgID-MoesifKey map.
+     * Will refresh/refill the  orgID-MoesifKey map.
+     */
+    public void initOrRefreshOrgIDMoesifKeyMap() {
+        int attempts = MoesifMicroserviceConstants.NUM_RETRY_ATTEMPTS;
+        try {
+            callListResource();
+        } catch (IOException | APICallException ex) {
+            // TODO: Separate retry logic to a separate class.
+            log.error("First attempt failed,retrying.", ex.getMessage());
+            while (attempts > 0) {
+                attempts--;
+                try {
+                    Thread.sleep(MoesifMicroserviceConstants.TIME_TO_WAIT);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                try {
+                    callListResource();
+                } catch (IOException | APICallException e) {
+                    log.error("Retry attempt failed and got: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Will retrieve single Moesif key corresponding to given organization ID.
+     * @param orgID
+     * @return Moesif Key corresponding orgID
+     */
+    public String getMoesifKey(String orgID) {
+        String response;
+        int attempts = MoesifMicroserviceConstants.NUM_RETRY_ATTEMPTS;
+        try {
+            response = callDetailResource(orgID);
+        } catch (IOException | APICallException ex) {
+            // TODO: Separate retry logic to a separate class.
+            log.error("First attempt failed,retrying.", ex.getMessage());
+            while (attempts > 0) {
+                attempts--;
+                try {
+                    Thread.sleep(MoesifMicroserviceConstants.TIME_TO_WAIT);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                try {
+                    response = callDetailResource(orgID);
+                    return response;
+                } catch (IOException | APICallException e) {
+                    log.error("Retry attempt failed and got: " + e.getMessage());
+                }
+            }
+            response = null;
+        }
+        return response;
+    }
+
+    /**
+     * Will remove Moesif key corresponding to organization ID.
+     * Existing Moesif SDK client associated with the moesif key will be also removed.
+     * @param orgID
+     */
+    public void removeMoesifKeyFromMap(String orgID) {
+        String moesifKey = orgIDMoesifKeyMap.remove(orgID);
+        moesifKeyClientMap.remove(moesifKey);
+    }
+
+    private void callListResource() throws IOException, APICallException {
+        URL obj;
+        try {
+            obj = new URL(MoesifMicroserviceConstants.LIST_URL);
+        } catch (MalformedURLException ex) {
+            log.error("Event will be dropped. Getting " + ex);
+            return;
+        }
+        String auth = gaAuthUsername + ":" + gaAuthPwd.toString();
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        String authHeaderValue = "Basic " + encodedAuth;
+
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        con.setRequestMethod("GET");
+        con.setRequestProperty("Authorization", authHeaderValue);
+        con.setRequestProperty("Content-Type", MoesifMicroserviceConstants.CONTENT_TYPE);
+        con.setReadTimeout(MoesifMicroserviceConstants.REQUEST_READ_TIMEOUT);
+        int responseCode = con.getResponseCode();
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+
+            updateMap(response.toString());
+            con.disconnect();
+        } else if (responseCode >= 400 && responseCode < 500) {
+            con.disconnect();
+            log.error("Event will be dropped. Getting " + responseCode);
+        } else {
+            con.disconnect();
+            throw new APICallException("Getting " + responseCode + " from the microservice and retrying.");
+        }
+
+    }
+
+    private String callDetailResource(String orgID) throws IOException, APICallException {
+        StringBuffer response = new StringBuffer();
+        String url = MoesifMicroserviceConstants.DETAIL_URL + "?" + MoesifMicroserviceConstants.QUERY_PARAM + "=" +
+                orgID;
+        URL obj;
+        try {
+            obj = new URL(url);
+        } catch (MalformedURLException ex) {
+            log.error("Event will be dropped. Getting " + ex);
+            return null;
+        }
+        String auth = gaAuthUsername + ":" + gaAuthPwd.toString();
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        String authHeaderValue = "Basic " + encodedAuth;
+
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        con.setRequestMethod("GET");
+        con.setRequestProperty("Content-Type", MoesifMicroserviceConstants.CONTENT_TYPE);
+        con.setRequestProperty("Authorization", authHeaderValue);
+        con.setReadTimeout(MoesifMicroserviceConstants.REQUEST_READ_TIMEOUT);
+        int responseCode = con.getResponseCode();
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String inputLine;
+
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+
+            updateMoesifKey(response.toString());
+            con.disconnect();
+        } else if (responseCode >= 400 && responseCode < 500) {
+            con.disconnect();
+            log.error("Event will be dropped. Getting " + responseCode);
+            return null;
+        } else {
+            con.disconnect();
+            throw new APICallException("Getting " + responseCode + " from the microservice and retrying.");
+        }
+        return response.toString();
+    }
+
+    private void updateMoesifKey(String response) {
+        Gson gson = new Gson();
+        String json = response;
+        MoesifKeyEntry newKey = gson.fromJson(json, MoesifKeyEntry.class);
+        String orgID = newKey.getOrganization_id();
+        String moesifKey = newKey.getMoesif_key();
+        orgIDMoesifKeyMap.put(orgID, moesifKey);
+        moesifKeyClientMap.put(moesifKey, new MoesifAPIClient(moesifKey));
+    }
+
+    private void updateMap(String response) {
+        Gson gson = new Gson();
+        String json = response;
+        Type collectionType = new TypeToken<Collection<MoesifKeyEntry>>() {
+        }.getType();
+        Collection<MoesifKeyEntry> newKeys = gson.fromJson(json, collectionType);
+
+        for (MoesifKeyEntry entry : newKeys) {
+            String orgID = entry.getOrganization_id();
+            String moesifKey = entry.getMoesif_key();
+            orgIDMoesifKeyMap.put(orgID, moesifKey);
+            moesifKeyClientMap.put(moesifKey, new MoesifAPIClient(moesifKey));
+        }
+    }
+
+    /**
+     * returning orgID-MoesifKey map.
+     * @return
+     */
+    public ConcurrentHashMap<String, String> getMoesifKeyMap() {
+        return orgIDMoesifKeyMap;
+    }
+
+    /**
+     * returning Moesif SDK client associated with the given Moesif key.
+     * @param moesifKey
+     * @return
+     */
+    public MoesifAPIClient getMoesifClient(String moesifKey) {
+        return moesifKeyClientMap.get(moesifKey);
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -34,10 +34,8 @@ import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.HttpsURLConnection;
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -21,9 +21,6 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.moesif.api.MoesifAPIClient;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.am.analytics.publisher.exception.APICallException;
@@ -37,8 +34,10 @@ import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.HttpsURLConnection;
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -143,14 +143,8 @@ public class MoesifKeyRetriever {
 
     private void callListResource() throws IOException, APICallException {
         final URL obj;
-        String[] urlWhiteArr = {"example.com", "www.example.com"};
-        List<String> urlWhiteList = Arrays.asList(urlWhiteArr);
-
         try {
             obj = new URL(MoesifMicroserviceConstants.LIST_URL);
-            if (urlWhiteList.contains(obj.getHost())) {
-                throw new MalformedURLException("Received a malformed url");
-            }
         } catch (MalformedURLException ex) {
             log.error("Event will be dropped. Getting", ex);
             return;
@@ -196,14 +190,9 @@ public class MoesifKeyRetriever {
         StringBuffer response = new StringBuffer();
         final String url = MoesifMicroserviceConstants.DETAIL_URL_WITH_QUERY + orgID;
         final URL obj;
-        String[] urlWhiteArr = {"example.com", "www.example.com"};
-        List<String> urlWhiteList = Arrays.asList(urlWhiteArr);
 
         try {
             obj = new URL(url);
-            if (urlWhiteList.contains(obj.getHost())) {
-                throw new MalformedURLException("Received a malformed url");
-            }
         } catch (MalformedURLException ex) {
             log.error("Event will be dropped. Getting", ex);
             return null;
@@ -260,7 +249,8 @@ public class MoesifKeyRetriever {
         Gson gson = new Gson();
         String json = response;
 
-        Type collectionType = new InnerTypeToken<Collection<MoesifKeyEntry>>().getType();
+        Type collectionType = new TypeToken<Collection<MoesifKeyEntry>>() {
+        }.getType();
         Collection<MoesifKeyEntry> newKeys = gson.fromJson(json, collectionType);
 
         for (MoesifKeyEntry entry : newKeys) {
@@ -290,12 +280,4 @@ public class MoesifKeyRetriever {
         return moesifKeyClientMap.get(moesifKey);
     }
 
-    /**
-     * Named inner class for TypeToken protected class.
-     *
-     * @param <T>
-     */
-    static class InnerTypeToken<T> extends TypeToken<T> {
-
-    }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -31,13 +31,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.HttpsURLConnection;
 
 /**
  * Responsible for calling the Moesif microservice and refresh/init entire internal map(organization, moesif key) or
@@ -149,13 +149,13 @@ public class MoesifKeyRetriever {
         String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
         String authHeaderValue = "Basic " + encodedAuth;
 
-        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
         con.setRequestMethod("GET");
         con.setRequestProperty("Authorization", authHeaderValue);
         con.setRequestProperty("Content-Type", MoesifMicroserviceConstants.CONTENT_TYPE);
         con.setReadTimeout(MoesifMicroserviceConstants.REQUEST_READ_TIMEOUT);
         int responseCode = con.getResponseCode();
-        if (responseCode == HttpURLConnection.HTTP_OK) {
+        if (responseCode == HttpsURLConnection.HTTP_OK) {
             BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
             String inputLine;
             StringBuffer response = new StringBuffer();
@@ -192,13 +192,13 @@ public class MoesifKeyRetriever {
         String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
         String authHeaderValue = "Basic " + encodedAuth;
 
-        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
         con.setRequestMethod("GET");
         con.setRequestProperty("Content-Type", MoesifMicroserviceConstants.CONTENT_TYPE);
         con.setRequestProperty("Authorization", authHeaderValue);
         con.setReadTimeout(MoesifMicroserviceConstants.REQUEST_READ_TIMEOUT);
         int responseCode = con.getResponseCode();
-        if (responseCode == HttpURLConnection.HTTP_OK) {
+        if (responseCode == HttpsURLConnection.HTTP_OK) {
             BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
             String inputLine;
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -91,7 +91,7 @@ public class MoesifKeyRetriever {
                 try {
                     callListResource();
                 } catch (IOException | APICallException e) {
-                    log.error("Retry attempt failed." + e);
+                    log.error("Retry attempt failed.", e);
                 }
             }
         }
@@ -122,7 +122,7 @@ public class MoesifKeyRetriever {
                     response = callDetailResource(orgID);
                     return response;
                 } catch (IOException | APICallException e) {
-                    log.error("Retry attempt failed." + e);
+                    log.error("Retry attempt failed.", e);
                 }
             }
             response = null;
@@ -152,7 +152,7 @@ public class MoesifKeyRetriever {
                 throw new MalformedURLException("Received a malformed url");
             }
         } catch (MalformedURLException ex) {
-            log.error("Event will be dropped. Getting" + ex);
+            log.error("Event will be dropped. Getting", ex);
             return;
         }
         String auth = gaAuthUsername + ":" + gaAuthPwd;
@@ -201,12 +201,12 @@ public class MoesifKeyRetriever {
         List<String> urlWhiteList = Arrays.asList(urlWhiteArr);
 
         try {
-            obj = new URL(MoesifMicroserviceConstants.LIST_URL);
+            obj = new URL(url);
             if (urlWhiteList.contains(obj.getHost())) {
                 throw new MalformedURLException("Received a malformed url");
             }
         } catch (MalformedURLException ex) {
-            log.error("Event will be dropped. Getting" + ex);
+            log.error("Event will be dropped. Getting", ex);
             return null;
         }
         String auth = gaAuthUsername + ":" + gaAuthPwd;
@@ -260,8 +260,8 @@ public class MoesifKeyRetriever {
     private void updateMap(String response) {
         Gson gson = new Gson();
         String json = response;
-        Type collectionType = new TypeToken<Collection<MoesifKeyEntry>>() {
-        }.getType();
+
+        Type collectionType = new innerTypeToken<Collection<MoesifKeyEntry>>().getType();
         Collection<MoesifKeyEntry> newKeys = gson.fromJson(json, collectionType);
 
         for (MoesifKeyEntry entry : newKeys) {
@@ -289,5 +289,9 @@ public class MoesifKeyRetriever {
      */
     public MoesifAPIClient getMoesifClient(String moesifKey) {
         return moesifKeyClientMap.get(moesifKey);
+    }
+
+    static class innerTypeToken<T> extends TypeToken<T> {
+
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -17,6 +17,7 @@
  */
 
 package org.wso2.am.analytics.publisher.util;
+
 /**
  * Class to hold String constants.
  */
@@ -105,4 +106,8 @@ public class Constants {
     public static final int DEFAULT_WORKER_THREADS = 1;
     public static final int DEFAULT_FLUSHING_DELAY = 15;
     public static final int USER_AGENT_DEFAULT_CACHE_SIZE = 50;
+
+    // Moesif sdk related constants
+    public static final String MOESIF_CONTENT_TYPE_HEADER = "application/json";
+
 }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MoesifMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MoesifMetricBuilderTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.am.analytics.publisher.exception.MetricCreationException;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.am.analytics.publisher.reporter.moesif.EventQueue;
+import org.wso2.am.analytics.publisher.reporter.moesif.MoesifCounterMetric;
+import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
+import org.wso2.am.analytics.publisher.util.Constants;
+
+public class MoesifMetricBuilderTestCase {
+    private static final Logger log = LoggerFactory.getLogger(MoesifMetricBuilderTestCase.class);
+
+    private MetricEventBuilder builder;
+
+    @BeforeMethod
+    public void createBuilder() throws MetricCreationException {
+        MoesifKeyRetriever keyRetriever = MoesifKeyRetriever.getInstance("some_username", "some_password");
+        EventQueue queue = new EventQueue(100, 1, keyRetriever);
+        MoesifCounterMetric metric = new MoesifCounterMetric("test.builder.metric",queue,MetricSchema.CHOREO_RESPONSE);
+        builder = metric.getEventBuilder();
+    }
+
+    @Test(expectedExceptions = MetricReportingException.class)
+    public void testMissingAttributes() throws MetricCreationException, MetricReportingException {
+        builder.addAttribute(Constants.REQUEST_TIMESTAMP, System.currentTimeMillis())
+                .addAttribute(Constants.CORRELATION_ID, "1234-4567")
+                .addAttribute(Constants.KEY_TYPE, "prod")
+                .addAttribute(Constants.API_ID, "9876-54f1")
+                .addAttribute(Constants.API_NAME, "PizzaShack")
+                .addAttribute(Constants.API_VERSION, "1.0.0")
+                .addAttribute(Constants.API_CREATION, "admin")
+                .addAttribute(Constants.API_METHOD, "POST")
+                .addAttribute(Constants.API_METHOD, "POST")
+                .addAttribute(Constants.API_RESOURCE_TEMPLATE, "/resource/{value}")
+                .addAttribute(Constants.API_CREATOR_TENANT_DOMAIN, "carbon.super")
+                .addAttribute(Constants.DESTINATION, "localhost:8080")
+                .addAttribute(Constants.APPLICATION_ID, "3445-6778")
+                .addAttribute(Constants.APPLICATION_NAME, "default")
+                .addAttribute(Constants.APPLICATION_OWNER, "admin")
+                .addAttribute(Constants.REGION_ID, "NA")
+                .addAttribute(Constants.GATEWAY_TYPE, "Synapse")
+                .addAttribute(Constants.USER_AGENT, "Mozilla")
+                .addAttribute(Constants.PROXY_RESPONSE_CODE, 401)
+                .addAttribute(Constants.TARGET_RESPONSE_CODE, "someString")
+                .addAttribute(Constants.RESPONSE_CACHE_HIT, true)
+                .addAttribute(Constants.RESPONSE_LATENCY, 2000)
+                .addAttribute(Constants.BACKEND_LATENCY, 3000)
+                .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, "1000")
+                .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000)
+                .addAttribute(Constants.USER_IP, "127.0.0.1")
+                .build();
+    }
+
+    @Test(expectedExceptions = MetricReportingException.class)
+    public void testAttributesWithInvalidTypes() throws MetricCreationException, MetricReportingException {
+        builder.addAttribute(Constants.REQUEST_TIMESTAMP, System.currentTimeMillis())
+                .addAttribute(Constants.CORRELATION_ID, "1234-4567")
+                .addAttribute(Constants.ORGANIZATION_ID, "wso2.com")
+                .addAttribute(Constants.KEY_TYPE, "prod")
+                .addAttribute(Constants.API_ID, "9876-54f1")
+                .addAttribute(Constants.API_NAME, "PizzaShack")
+                .addAttribute(Constants.API_VERSION, "1.0.0")
+                .addAttribute(Constants.API_CREATION, "admin")
+                .addAttribute(Constants.API_METHOD, "POST")
+                .addAttribute(Constants.API_METHOD, "POST")
+                .addAttribute(Constants.API_CONTEXT, "/v1/")
+                .addAttribute(Constants.API_RESOURCE_TEMPLATE, "/resource/{value}")
+                .addAttribute(Constants.API_CREATOR_TENANT_DOMAIN, "carbon.super")
+                .addAttribute(Constants.DESTINATION, "localhost:8080")
+                .addAttribute(Constants.APPLICATION_ID, "3445-6778")
+                .addAttribute(Constants.APPLICATION_NAME, "default")
+                .addAttribute(Constants.APPLICATION_OWNER, "admin")
+                .addAttribute(Constants.REGION_ID, "NA")
+                .addAttribute(Constants.GATEWAY_TYPE, "Synapse")
+                .addAttribute(Constants.USER_AGENT, "Mozilla")
+                .addAttribute(Constants.USER_NAME, "admin")
+                .addAttribute(Constants.PROXY_RESPONSE_CODE, 401)
+                .addAttribute(Constants.TARGET_RESPONSE_CODE, "someString")
+                .addAttribute(Constants.RESPONSE_CACHE_HIT, true)
+                .addAttribute(Constants.RESPONSE_LATENCY, 2000)
+                .addAttribute(Constants.BACKEND_LATENCY, 3000)
+                .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, "1000")
+                .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000)
+                .addAttribute(Constants.USER_IP, "127.0.0.1")
+                .build();
+    }
+
+    @Test
+    public void testMetricBuilder() throws MetricCreationException, MetricReportingException {
+        String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, "
+                + "like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3";
+
+        Map<String, Object> eventMap = builder
+                .addAttribute(Constants.REQUEST_TIMESTAMP, OffsetDateTime.now(Clock.systemUTC()).toString())
+                .addAttribute(Constants.CORRELATION_ID, "1234-4567")
+                .addAttribute(Constants.ORGANIZATION_ID, "wso2.com")
+                .addAttribute(Constants.KEY_TYPE, "prod")
+                .addAttribute(Constants.API_ID, "9876-54f1")
+                .addAttribute(Constants.API_TYPE, "HTTP")
+                .addAttribute(Constants.API_NAME, "PizzaShack")
+                .addAttribute(Constants.API_VERSION, "1.0.0")
+                .addAttribute(Constants.API_CREATION, "admin")
+                .addAttribute(Constants.API_METHOD, "POST")
+                .addAttribute(Constants.API_CONTEXT, "/v1/")
+                .addAttribute(Constants.USER_NAME, "admin")
+                .addAttribute(Constants.API_RESOURCE_TEMPLATE, "/resource/{value}")
+                .addAttribute(Constants.API_CREATOR_TENANT_DOMAIN, "carbon.super")
+                .addAttribute(Constants.DESTINATION, "localhost:8080")
+                .addAttribute(Constants.APPLICATION_ID, "3445-6778")
+                .addAttribute(Constants.APPLICATION_NAME, "default")
+                .addAttribute(Constants.APPLICATION_OWNER, "admin")
+                .addAttribute(Constants.REGION_ID, "NA")
+                .addAttribute(Constants.GATEWAY_TYPE, "Synapse")
+                .addAttribute(Constants.USER_AGENT_HEADER, uaString)
+                .addAttribute(Constants.PROXY_RESPONSE_CODE, 401)
+                .addAttribute(Constants.TARGET_RESPONSE_CODE, 401)
+                .addAttribute(Constants.RESPONSE_CACHE_HIT, true)
+                .addAttribute(Constants.RESPONSE_LATENCY, 2000L)
+                .addAttribute(Constants.BACKEND_LATENCY, 3000L)
+                .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, 1000L)
+                .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000L)
+                .addAttribute(Constants.USER_IP, "127.0.0.1")
+                .build();
+
+        Assert.assertFalse(eventMap.isEmpty());
+        // We expect only 29 attributes in Moesif scenario unlike in choreo scenario. In choreo scenario we parse user agent header,
+        // and build additional attribute.
+        Assert.assertEquals(eventMap.size(), 29, "Some attributes are missing from the resulting event map");
+        Assert.assertEquals(eventMap.get(Constants.ORGANIZATION_ID), "wso2.com",
+                "Organization ID should be wso2.com");
+    }
+}

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MoesifMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MoesifMetricBuilderTestCase.java
@@ -18,9 +18,6 @@
 
 package org.wso2.am.analytics.publisher;
 
-import java.time.Clock;
-import java.time.OffsetDateTime;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -34,6 +31,9 @@ import org.wso2.am.analytics.publisher.reporter.moesif.EventQueue;
 import org.wso2.am.analytics.publisher.reporter.moesif.MoesifCounterMetric;
 import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
 import org.wso2.am.analytics.publisher.util.Constants;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Map;
 
 public class MoesifMetricBuilderTestCase {
     private static final Logger log = LoggerFactory.getLogger(MoesifMetricBuilderTestCase.class);
@@ -44,7 +44,8 @@ public class MoesifMetricBuilderTestCase {
     public void createBuilder() throws MetricCreationException {
         MoesifKeyRetriever keyRetriever = MoesifKeyRetriever.getInstance("some_username", "some_password");
         EventQueue queue = new EventQueue(100, 1, keyRetriever);
-        MoesifCounterMetric metric = new MoesifCounterMetric("test.builder.metric",queue,MetricSchema.CHOREO_RESPONSE);
+        MoesifCounterMetric metric =
+                new MoesifCounterMetric("test.builder.metric", queue, MetricSchema.CHOREO_RESPONSE);
         builder = metric.getEventBuilder();
     }
 
@@ -151,8 +152,9 @@ public class MoesifMetricBuilderTestCase {
                 .build();
 
         Assert.assertFalse(eventMap.isEmpty());
-        // We expect only 29 attributes in Moesif scenario unlike in choreo scenario. In choreo scenario we parse user agent header,
-        // and build additional attribute.
+        // We expect only 29 attributes in Moesif scenario unlike in choreo scenario.
+        // In choreo scenario we parse user agent header,
+        // and build one additional attribute.
         Assert.assertEquals(eventMap.size(), 29, "Some attributes are missing from the resulting event map");
         Assert.assertEquals(eventMap.get(Constants.ORGANIZATION_ID), "wso2.com",
                 "Organization ID should be wso2.com");

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -58,4 +58,8 @@
         <Class name="org.wso2.am.analytics.publisher.auth.AuthProxyUtils"/>
         <Bug pattern="IMPROPER_UNICODE"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.reporter.moesif.EventQueue"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+    </Match>
 </FindBugsFilter>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -63,11 +63,19 @@
         <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
     </Match>
     <Match>
-        <Class name="org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever"/>
+        <Class name="org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever$1"/>
         <Bug Pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
     </Match>
     <Match>
         <Class name="org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever"/>
+        <Bug Pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.client.MoesifClient"/>
+        <Bug Pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.reporter.moesif.ParallelQueueWorker"/>
         <Bug Pattern="URLCONNECTION_SSRF_FD"/>
     </Match>
 </FindBugsFilter>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -62,4 +62,12 @@
         <Class name="org.wso2.am.analytics.publisher.reporter.moesif.EventQueue"/>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever"/>
+        <Bug Pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
+    </Match>
+    <Match>
+        <Class name="org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever"/>
+        <Bug Pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.moesif.api</groupId>
+                <artifactId>moesifapi</artifactId>
+                <version>1.6.17</version>
+            </dependency>
+            <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-messaging-eventhubs</artifactId>
                 <version>${azure.messaging.evenhub.version}</version>


### PR DESCRIPTION
## Purpose
Choreo platform user should be able to send API analytics to Moesif platform [[1]](https://www.moesif.com/) given that user has provided a one-time write only Moesif key [[2]](https://www.moesif.com/docs/api#moesif-api-reference).  

## Goals
Should be able to direct analytics events to Moesif platform securely, reliably by adhering to multi-tenant architecture.

## Approach
This implementation shares many similarities to already existing Reporters.
Only addition is Moesif reporter is communicating with an external microservice to handle end user details. 

## Automation tests
 - Unit tests 
   > Covered for Moesif event builder

### Status
Draft (Microservice should be in prod to proceed ).
