### PR TITLE
Fixes for apiContext error in Choreo and ELK

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
@@ -56,6 +56,11 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
     @Override
     public boolean validate() throws MetricReportingException {
         if (!isBuilt) {
+            eventMap.remove(Constants.USER_NAME);
+            Map<String, String> propertyMap = (Map<String, String>) eventMap.remove(Constants.PROPERTIES);
+            if (propertyMap != null) {
+                copyDefaultPropertiesToRootLevel(propertyMap);
+            }
             for (Map.Entry<String, Class> entry : requiredAttributes.entrySet()) {
                 Object attribute = eventMap.get(entry.getKey());
                 if (attribute == null) {
@@ -111,6 +116,13 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
         }
         eventMap.put(Constants.USER_AGENT, browser);
         eventMap.put(Constants.PLATFORM, platform);
+    }
+
+    private void copyDefaultPropertiesToRootLevel(Map<String, String> properties) {
+        String apiContext = properties.remove(Constants.API_CONTEXT);
+        properties.remove(Constants.USER_NAME);
+        eventMap.put(Constants.API_CONTEXT, apiContext);
+        eventMap.put(Constants.PROPERTIES, properties);
     }
 
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/elk/ELKMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/elk/ELKMetricEventBuilder.java
@@ -62,10 +62,6 @@ public class ELKMetricEventBuilder extends AbstractMetricEventBuilder {
             if (userAgentHeader != null) {
                 setUserAgentProperties(userAgentHeader);
             }
-            Map<String, String> propertyMap = (Map<String, String>) eventMap.remove(Constants.PROPERTIES);
-            if (propertyMap != null) {
-                copyDefaultPropertiesToRootLevel(propertyMap);
-            }
             isBuilt = true;
         }
         return eventMap;
@@ -74,6 +70,10 @@ public class ELKMetricEventBuilder extends AbstractMetricEventBuilder {
     @Override
     public boolean validate() throws MetricReportingException {
         if (!isBuilt) {
+            Map<String, String> propertyMap = (Map<String, String>) eventMap.remove(Constants.PROPERTIES);
+            if (propertyMap != null) {
+                copyDefaultPropertiesToRootLevel(propertyMap);
+            }
             for (Map.Entry<String, Class> entry : requiredAttributes.entrySet()) {
                 Object attribute = eventMap.get(entry.getKey());
                 if (attribute == null) {
@@ -115,8 +115,10 @@ public class ELKMetricEventBuilder extends AbstractMetricEventBuilder {
     }
 
     private void copyDefaultPropertiesToRootLevel(Map<String, String> properties) {
-        // No need to put apiContext and userName to root level from the properties bag
-        // since the response schema is modified to have both userName and apiContext
+        String apiContext = properties.remove(Constants.API_CONTEXT);
+        String userName = properties.remove(Constants.USER_NAME);
+        eventMap.put(Constants.API_CONTEXT, apiContext);
+        eventMap.put(Constants.USER_NAME, userName);
         eventMap.put(Constants.PROPERTIES, properties);
     }
 }


### PR DESCRIPTION
Reason: When Choreo analytics was enabled, it popped up an error missing the apiContext. The reason was the apiContext was not in the root level although there is a validation check for that in the root level. 

Fix for Choreo: Hence apiContext was brought into the root level to enable the validation check. Further, it was noted that the userName was available there and it was removed from the eventMap due to privacy concerns.

Fix for ELK: Here, the content in the properties was brought into the root level in the builder. But, the validator runs before the builder. Hence, the content has to be brought into the builder when the validator runs.

Issue: https://github.com/wso2/api-manager/issues/1435