### PR TITLE
Upgrade ua-parser and azure eventhub dependencies

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>log4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
         <google.gson.import.version.range>[2.8.0, 3.0.0)</google.gson.import.version.range>
         <feign.import.version.range>[11.0.0, 12.0.0)</feign.import.version.range>
         <apache.log4j.import.version.range>[2.17.0, 3.0.0)</apache.log4j.import.version.range>
-        <ua_parser.version>1.5.4.wso2v2</ua_parser.version>
+        <ua_parser.version>1.5.4.wso2v3</ua_parser.version>
         <ua_parser.import.version.range>[1.3.0,2)</ua_parser.import.version.range>
         <jacoco.version>0.8.6</jacoco.version>
         <apache.commons.lang3.version>3.10</apache.commons.lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
                 <version>${ua_parser.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-httpclient</artifactId>
                 <version>${openfeign.version}</version>
@@ -296,11 +302,11 @@
         <carbon.feature.plugin.version>3.1.4</carbon.feature.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <azure-core.version>1.9.0.wso2v1</azure-core.version>
-        <azure-core-amqp.version>1.6.0.wso2v1</azure-core-amqp.version>
+        <azure-core.version>1.43.0.wso2v1</azure-core.version>
+        <azure-core-amqp.version>2.8.9.wso2v1</azure-core-amqp.version>
         <azure-qpid-proton-j-extensions.version>1.2.4.wso2v1</azure-qpid-proton-j-extensions.version>
-        <azure-messaging-eventhubs.version>1.6.0.wso2v1</azure-messaging-eventhubs.version>
-        <reactor-core.version>3.3.9.wso2v1</reactor-core.version>
+        <azure-messaging-eventhubs.version>5.16.0.wso2v1</azure-messaging-eventhubs.version>
+        <reactor-core.version>3.4.31.wso2v1</reactor-core.version>
         <proton-j.version>0.33.4</proton-j.version>
         <openfeign.version>11.0</openfeign.version>
         <azure.core.import.version.range>[1.9.0, 2.0.0)</azure.core.import.version.range>
@@ -309,8 +315,9 @@
         <google.gson.import.version.range>[2.8.0, 3.0.0)</google.gson.import.version.range>
         <feign.import.version.range>[11.0.0, 12.0.0)</feign.import.version.range>
         <apache.log4j.import.version.range>[2.17.0, 3.0.0)</apache.log4j.import.version.range>
-        <ua_parser.version>1.5.4.wso2v3</ua_parser.version>
+        <ua_parser.version>1.6.1.wso2v1</ua_parser.version>
         <ua_parser.import.version.range>[1.3.0,2)</ua_parser.import.version.range>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <jacoco.version>0.8.6</jacoco.version>
         <apache.commons.lang3.version>3.10</apache.commons.lang3.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>


### PR DESCRIPTION
## Purpose
Upgrade 
- ua-parser -> 1.6.1.wso2v1
- azure core -> 1.43.0.wso2v1
- azure core amqp -> 2.8.9.wso2v1
- azure messaging -> 1.6.0.wso2v1
- reactor core -> 3.4.31.wso2v1
