### PR TITLE
Refactor for AI API Analytics

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -140,6 +140,7 @@
                             org.wso2.am.analytics.publisher.exception.*;version="${project.version}",
                             org.wso2.am.analytics.publisher.auth.*;version="${project.version}",
                             org.wso2.am.analytics.publisher.util.*;version="${project.version}",
+                            org.wso2.am.analytics.publisher.properties.*;version="${project.version}",
                         </Export-Package>
                         <Private-Package>
                         </Private-Package>

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AIMetadata.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AIMetadata.java
@@ -18,6 +18,8 @@
 
 package org.wso2.am.analytics.publisher.properties;
 
+import org.wso2.am.analytics.publisher.util.Constants;
+
 import java.util.Map;
 
 /**
@@ -39,9 +41,9 @@ public class AIMetadata {
      * Constructor to initialize from a Map
      */
     public AIMetadata(Map<String, Object> map) {
-        this.vendorName = (String) map.get("vendorName");
-        this.model = (String) map.get("model");
-        this.vendorVersion = (String) map.get("vendorVersion");
+        this.vendorName = (String) map.get(Constants.AI_VENDOR_NAME);
+        this.model = (String) map.get(Constants.AI_MODEL);
+        this.vendorVersion = (String) map.get(Constants.AI_VENDOR_VERSION);
     }
 
     /**
@@ -96,14 +98,5 @@ public class AIMetadata {
      */
     public void setVendorVersion(String vendorVersion) {
         this.vendorVersion = vendorVersion;
-    }
-
-    @Override
-    public String toString() {
-        return "AIMetadata{" +
-                "vendorName='" + vendorName + '\'' +
-                ", model='" + model + '\'' +
-                ", vendorVersion='" + vendorVersion + '\'' +
-                '}';
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AIMetadata.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AIMetadata.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.properties;
+
+import java.util.Map;
+
+/**
+ * Represents metadata information about the AI model used in API processing.
+ * This includes the vendor details, model name, and version.
+ */
+public class AIMetadata {
+    private String vendorName;
+    private String model;
+    private String vendorVersion;
+
+    /**
+     * Default constructor.
+     */
+    public AIMetadata() {
+    }
+
+    /**
+     * Constructor to initialize from a Map
+     */
+    public AIMetadata(Map<String, Object> map) {
+        this.vendorName = (String) map.get("vendorName");
+        this.model = (String) map.get("model");
+        this.vendorVersion = (String) map.get("vendorVersion");
+    }
+
+    /**
+     * Gets the name of the AI model vendor.
+     *
+     * @return The AI vendor name.
+     */
+    public String getVendorName() {
+        return vendorName;
+    }
+
+    /**
+     * Sets the name of the AI model vendor.
+     *
+     * @param vendorName The AI vendor name.
+     */
+    public void setVendorName(String vendorName) {
+        this.vendorName = vendorName;
+    }
+
+    /**
+     * Gets the AI model name.
+     *
+     * @return The AI model name.
+     */
+    public String getModel() {
+        return model;
+    }
+
+    /**
+     * Sets the AI model name.
+     *
+     * @param model The AI model name.
+     */
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    /**
+     * Gets the version of the AI model provided by the vendor.
+     *
+     * @return The AI model vendor version.
+     */
+    public String getVendorVersion() {
+        return vendorVersion;
+    }
+
+    /**
+     * Sets the version of the AI model provided by the vendor.
+     *
+     * @param vendorVersion The AI model vendor version.
+     */
+    public void setVendorVersion(String vendorVersion) {
+        this.vendorVersion = vendorVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "AIMetadata{" +
+                "vendorName='" + vendorName + '\'' +
+                ", model='" + model + '\'' +
+                ", vendorVersion='" + vendorVersion + '\'' +
+                '}';
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AITokenUsage.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AITokenUsage.java
@@ -18,6 +18,8 @@
 
 package org.wso2.am.analytics.publisher.properties;
 
+import org.wso2.am.analytics.publisher.util.Constants;
+
 import java.util.Map;
 
 /**
@@ -40,9 +42,9 @@ public class AITokenUsage {
      * Constructor to initialize from a Map
      */
     public AITokenUsage(Map<String, Object> map) {
-        this.promptTokens = (int) map.get("promptTokens");
-        this.totalTokens = (int) map.get("totalTokens");
-        this.completionTokens = (int) map.get("completionTokens");
+        this.promptTokens = (int) map.get(Constants.AI_PROMPT_TOKEN_USAGE);
+        this.totalTokens = (int) map.get(Constants.AI_TOTAL_TOKEN_USAGE);
+        this.completionTokens = (int) map.get(Constants.AI_COMPLETION_TOKEN_USAGE);
     }
 
 
@@ -98,14 +100,5 @@ public class AITokenUsage {
      */
     public void setCompletionTokens(int completionTokens) {
         this.completionTokens = completionTokens;
-    }
-
-    @Override
-    public String toString() {
-        return "AITokenUsage{" +
-                "promptTokens=" + promptTokens +
-                ", totalTokens=" + totalTokens +
-                ", completionTokens=" + completionTokens +
-                '}';
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AITokenUsage.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/AITokenUsage.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.properties;
+
+import java.util.Map;
+
+/**
+ * Represents the AI token usage details, including prompt tokens,
+ * total tokens, and completion tokens.
+ * This helps in tracking API usage costs and resource consumption.
+ */
+public class AITokenUsage {
+    private int promptTokens;
+    private int totalTokens;
+    private int completionTokens;
+
+    /**
+     * Default constructor.
+     */
+    public AITokenUsage() {
+    }
+
+    /**
+     * Constructor to initialize from a Map
+     */
+    public AITokenUsage(Map<String, Object> map) {
+        this.promptTokens = (int) map.get("promptTokens");
+        this.totalTokens = (int) map.get("totalTokens");
+        this.completionTokens = (int) map.get("completionTokens");
+    }
+
+
+    /**
+     * Gets the number of tokens used in the prompt.
+     *
+     * @return The number of prompt tokens.
+     */
+    public int getPromptTokens() {
+        return promptTokens;
+    }
+
+    /**
+     * Sets the number of tokens used in the prompt.
+     *
+     * @param promptTokens The number of prompt tokens.
+     */
+    public void setPromptTokens(int promptTokens) {
+        this.promptTokens = promptTokens;
+    }
+
+    /**
+     * Gets the total number of tokens used in the request.
+     *
+     * @return The total number of tokens.
+     */
+    public int getTotalTokens() {
+        return totalTokens;
+    }
+
+    /**
+     * Sets the total number of tokens used in the request.
+     *
+     * @param totalTokens The total number of tokens.
+     */
+    public void setTotalTokens(int totalTokens) {
+        this.totalTokens = totalTokens;
+    }
+
+    /**
+     * Gets the number of tokens used in the AI model's response.
+     *
+     * @return The number of completion tokens.
+     */
+    public int getCompletionTokens() {
+        return completionTokens;
+    }
+
+    /**
+     * Sets the number of tokens used in the AI model's response.
+     *
+     * @param completionTokens The number of completion tokens.
+     */
+    public void setCompletionTokens(int completionTokens) {
+        this.completionTokens = completionTokens;
+    }
+
+    @Override
+    public String toString() {
+        return "AITokenUsage{" +
+                "promptTokens=" + promptTokens +
+                ", totalTokens=" + totalTokens +
+                ", completionTokens=" + completionTokens +
+                '}';
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/Properties.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/Properties.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.analytics.publisher.properties;
+
+/**
+ * Represents the properties associated with an API request,
+ * including routing information, AI-related metadata, and AI token usage.
+ */
+public class Properties {
+    private boolean isEgress;
+    private String subType;
+    private AIMetadata aiMetadata;
+    private AITokenUsage aiTokenUsage;
+
+    /**
+     * Default constructor.
+     */
+    public Properties() {
+    }
+
+    /**
+     * Checks if the request is an egress request.
+     *
+     * @return {@code true} if the request is egress, {@code false} otherwise.
+     */
+    public boolean isEgress() {
+        return isEgress;
+    }
+
+    /**
+     * Sets whether the request is an egress request.
+     *
+     * @param egress {@code true} if the request is egress, {@code false} otherwise.
+     */
+    public void setEgress(boolean egress) {
+        isEgress = egress;
+    }
+
+    /**
+     * Gets the subtype of the API request.
+     *
+     * @return The API request subtype.
+     */
+    public String getSubType() {
+        return subType;
+    }
+
+    /**
+     * Sets the subtype of the API request.
+     *
+     * @param subType The API request subtype.
+     */
+    public void setSubType(String subType) {
+        this.subType = subType;
+    }
+
+    /**
+     * Gets the AI metadata associated with this request.
+     *
+     * @return The {@link AIMetadata} instance.
+     */
+    public AIMetadata getAiMetadata() {
+        return aiMetadata;
+    }
+
+    /**
+     * Sets the AI metadata for this request.
+     *
+     * @param aiMetadata The {@link AIMetadata} instance.
+     */
+    public void setAiMetadata(AIMetadata aiMetadata) {
+        this.aiMetadata = aiMetadata;
+    }
+
+    /**
+     * Gets the AI token usage details for this request.
+     *
+     * @return The {@link AITokenUsage} instance.
+     */
+    public AITokenUsage getAiTokenUsage() {
+        return aiTokenUsage;
+    }
+
+    /**
+     * Sets the AI token usage details for this request.
+     *
+     * @param aiTokenUsage The {@link AITokenUsage} instance.
+     */
+    public void setAiTokenUsage(AITokenUsage aiTokenUsage) {
+        this.aiTokenUsage = aiTokenUsage;
+    }
+
+    @Override
+    public String toString() {
+        return "Properties{" +
+                "isEgress=" + isEgress +
+                ", subType='" + subType + '\'' +
+                ", aiMetadata=" + aiMetadata +
+                ", aiTokenUsage=" + aiTokenUsage +
+                '}';
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/Properties.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/Properties.java
@@ -105,14 +105,4 @@ public class Properties {
     public void setAiTokenUsage(AITokenUsage aiTokenUsage) {
         this.aiTokenUsage = aiTokenUsage;
     }
-
-    @Override
-    public String toString() {
-        return "Properties{" +
-                "isEgress=" + isEgress +
-                ", subType='" + subType + '\'' +
-                ", aiMetadata=" + aiMetadata +
-                ", aiTokenUsage=" + aiTokenUsage +
-                '}';
-    }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultInputValidator.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultInputValidator.java
@@ -18,6 +18,7 @@
 
 package org.wso2.am.analytics.publisher.reporter.cloud;
 
+import org.wso2.am.analytics.publisher.properties.Properties;
 import org.wso2.am.analytics.publisher.reporter.MetricSchema;
 
 import java.util.AbstractMap;
@@ -50,6 +51,7 @@ import static org.wso2.am.analytics.publisher.util.Constants.ERROR_TYPE;
 import static org.wso2.am.analytics.publisher.util.Constants.GATEWAY_TYPE;
 import static org.wso2.am.analytics.publisher.util.Constants.KEY_TYPE;
 import static org.wso2.am.analytics.publisher.util.Constants.ORGANIZATION_ID;
+import static org.wso2.am.analytics.publisher.util.Constants.PROPERTIES;
 import static org.wso2.am.analytics.publisher.util.Constants.PROXY_RESPONSE_CODE;
 import static org.wso2.am.analytics.publisher.util.Constants.REGION_ID;
 import static org.wso2.am.analytics.publisher.util.Constants.REQUEST_MEDIATION_LATENCY;
@@ -94,7 +96,8 @@ public class DefaultInputValidator {
             new AbstractMap.SimpleImmutableEntry<>(BACKEND_LATENCY, Long.class),
             new AbstractMap.SimpleImmutableEntry<>(REQUEST_MEDIATION_LATENCY, Long.class),
             new AbstractMap.SimpleImmutableEntry<>(RESPONSE_MEDIATION_LATENCY, Long.class),
-            new AbstractMap.SimpleImmutableEntry<>(USER_IP, String.class))
+            new AbstractMap.SimpleImmutableEntry<>(USER_IP, String.class),
+            new AbstractMap.SimpleImmutableEntry<>(PROPERTIES, Properties.class))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     private static final Map<String, Class> faultSchema = Stream.of(
@@ -116,7 +119,8 @@ public class DefaultInputValidator {
             new AbstractMap.SimpleImmutableEntry<>(REGION_ID, String.class),
             new AbstractMap.SimpleImmutableEntry<>(GATEWAY_TYPE, String.class),
             new AbstractMap.SimpleImmutableEntry<>(PROXY_RESPONSE_CODE, Integer.class),
-            new AbstractMap.SimpleImmutableEntry<>(TARGET_RESPONSE_CODE, Integer.class))
+            new AbstractMap.SimpleImmutableEntry<>(TARGET_RESPONSE_CODE, Integer.class),
+            new AbstractMap.SimpleImmutableEntry<>(PROPERTIES, Properties.class))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     private static final Map<String, Class> choreoResponseSchema = Stream.of(

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/cloud/DefaultResponseMetricEventBuilder.java
@@ -22,6 +22,9 @@ import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.properties.AIMetadata;
+import org.wso2.am.analytics.publisher.properties.AITokenUsage;
+import org.wso2.am.analytics.publisher.properties.Properties;
 import org.wso2.am.analytics.publisher.reporter.AbstractMetricEventBuilder;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.reporter.MetricSchema;
@@ -61,6 +64,7 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
             Map<String, Object> propertyMap = (Map<String, Object>) eventMap.remove(Constants.PROPERTIES);
             if (propertyMap != null) {
                 copyDefaultPropertiesToRootLevel(propertyMap);
+                extractPropertyObject(propertyMap);
             }
             if (log.isDebugEnabled()) {
                 log.debug("Prepared event for publish to Choreo Analytics: " + new Gson().toJson(eventMap));
@@ -78,6 +82,27 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
             }
         }
         return true;
+    }
+
+    private void extractPropertyObject(Map<String, Object> properties) {
+        Properties propertyObject = new Properties();
+        if (properties.get(Constants.AI_METADATA) != null) {
+            Map<String, Object> aiMetadata = (Map<String, Object>) properties.remove(Constants.AI_METADATA);
+            propertyObject.setAiMetadata(new AIMetadata(aiMetadata));
+        }
+        if (properties.get(Constants.AI_TOKEN_USAGE) != null) {
+            Map<String, Object> aiTokenUsage = (Map<String, Object>) properties.remove(Constants.AI_TOKEN_USAGE);
+            propertyObject.setAiTokenUsage(new AITokenUsage(aiTokenUsage));
+        }
+        if (properties.get(Constants.IS_EGRESS) != null) {
+            boolean isEgress = (boolean) properties.remove(Constants.IS_EGRESS);
+            propertyObject.setEgress(isEgress);
+        }
+        if (properties.get(Constants.SUBTYPE) != null) {
+            String subType = (String) properties.remove(Constants.SUBTYPE);
+            propertyObject.setSubType(subType);
+        }
+        eventMap.put(Constants.PROPERTIES, propertyObject);
     }
 
     @Override
@@ -127,24 +152,7 @@ public class DefaultResponseMetricEventBuilder extends AbstractMetricEventBuilde
             String apiContext = (String) properties.remove(Constants.API_CONTEXT);
             eventMap.put(Constants.API_CONTEXT, apiContext);
         }
-        if (properties.get(Constants.AI_METADATA) != null) {
-            Object aiMetadata = properties.remove(Constants.AI_METADATA);
-            eventMap.put(Constants.AI_METADATA, aiMetadata);
-        }
-        if (properties.get(Constants.AI_TOKEN_USAGE) != null) {
-            Object aiTokenUsage = properties.remove(Constants.AI_TOKEN_USAGE);
-            eventMap.put(Constants.AI_TOKEN_USAGE, aiTokenUsage);
-        }
-        if (properties.get(Constants.IS_EGRESS) != null) {
-            boolean isEgress = (boolean) properties.remove(Constants.IS_EGRESS);
-            eventMap.put(Constants.IS_EGRESS, isEgress);
-        }
-        if (properties.get(Constants.SUBTYPE) != null) {
-            String subType = (String) properties.remove(Constants.SUBTYPE);
-            eventMap.put(Constants.SUBTYPE, subType);
-        }
         properties.remove(Constants.USER_NAME);
-        eventMap.put(Constants.PROPERTIES, properties);
     }
 
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -64,6 +64,12 @@ public class Constants {
     public static final String AI_TOKEN_USAGE = "aiTokenUsage";
     public static final String IS_EGRESS = "isEgress";
     public static final String SUBTYPE = "subtype";
+    public static final String AI_VENDOR_NAME = "vendorName";
+    public static final String AI_VENDOR_VERSION = "vendorVersion";
+    public static final String AI_MODEL = "model";
+    public static final String AI_PROMPT_TOKEN_USAGE = "promptTokens";
+    public static final String AI_COMPLETION_TOKEN_USAGE = "completionTokens";
+    public static final String AI_TOTAL_TOKEN_USAGE = "totalTokens";
 
     //Builder event types
     public static final String RESPONSE_EVENT_TYPE = "response";

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultFaultMetricBuilderTestCase.java
@@ -112,10 +112,11 @@ public class DefaultFaultMetricBuilderTestCase {
                 .addAttribute(Constants.GATEWAY_TYPE, "Synapse")
                 .addAttribute(Constants.PROXY_RESPONSE_CODE, 401)
                 .addAttribute(Constants.TARGET_RESPONSE_CODE, 401)
+                .addAttribute(Constants.PROPERTIES, new HashMap<String, Object>())
                 .build();
 
         Assert.assertFalse(eventMap.isEmpty());
-        Assert.assertEquals(eventMap.size(), 21, "Some attributes are missing from the resulting event map");
+        Assert.assertEquals(eventMap.size(), 22, "Some attributes are missing from the resulting event map");
         Assert.assertEquals(eventMap.get(Constants.EVENT_TYPE), "fault", "Event type should be set to fault");
         Assert.assertEquals(eventMap.get(Constants.API_TYPE), "HTTP", "API type should be set to HTTP");
     }

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultResponseMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/DefaultResponseMetricBuilderTestCase.java
@@ -132,10 +132,11 @@ public class DefaultResponseMetricBuilderTestCase {
                 .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, 1000L)
                 .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000L)
                 .addAttribute(Constants.USER_IP, "127.0.0.1")
+                .addAttribute(Constants.PROPERTIES, new HashMap<String, Object>())
                 .build();
 
         Assert.assertFalse(eventMap.isEmpty());
-        Assert.assertEquals(eventMap.size(), 29, "Some attributes are missing from the resulting event map");
+        Assert.assertEquals(eventMap.size(), 30, "Some attributes are missing from the resulting event map");
         Assert.assertEquals(eventMap.get(Constants.EVENT_TYPE), "response", "Event type should be set to fault");
         Assert.assertEquals(eventMap.get(Constants.USER_AGENT), "Mobile Safari",
                 "User agent should be set to Mobile Safari");

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/TestUtils.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/util/TestUtils.java
@@ -23,6 +23,7 @@ import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -60,7 +61,8 @@ public class TestUtils {
                 .addAttribute(Constants.BACKEND_LATENCY, 3000L)
                 .addAttribute(Constants.REQUEST_MEDIATION_LATENCY, 1000L)
                 .addAttribute(Constants.RESPONSE_MEDIATION_LATENCY, 1000L)
-                .addAttribute(Constants.USER_IP, "127.0.0.1");
+                .addAttribute(Constants.USER_IP, "127.0.0.1")
+                .addAttribute(Constants.PROPERTIES, new HashMap<String, Object>());
     }
 
     public static boolean isContains(List<String> messages, String message) {


### PR DESCRIPTION
## Purpose
The current implementation extracts AI API-related data to the root level of events sent to Azure Event Hub. However, Event Hub listens for data within the property bag. Previously, the property bag was removed from events because it was not included as a required field in the filtering criteria.

This PR refactors AI API-related data into the property bag and ensures it is retained in the filtering criteria before publishing.

## Issue
https://github.com/wso2/api-manager/issues/3129