### PR TITLE
Integrate Moesif Analytics with WSO2 API Manager

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -150,13 +150,11 @@
                             org.wso2.am.analytics.publisher.util.*;version="${project.version}",
                             org.wso2.am.analytics.publisher.properties.*;version="${project.version}",
                         </Export-Package>
-                        <Embed-Dependency>
-                            moesifapi;scope=compile|runtime;inline=false,
-                            unirest-java;scope=compile|runtime;inline=false,
-                            httpasyncclient;scope=compile|runtime;inline=false,
-                        </Embed-Dependency>
-                        <Embed-Transitive>true</Embed-Transitive>
                         <Private-Package>
+                            com.moesif.api.*;version="${moesif.api.version}",
+                            com.mashape.unirest.*,
+                            org.apache.http.impl.nio.*,
+                            org.apache.http.nio.*,
                         </Private-Package>
                         <Import-Package>
                             <!-- Exclude embedded packages from import -->

--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -32,6 +32,14 @@
             <artifactId>moesifapi</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.moesif.unirest</groupId>
+            <artifactId>unirest-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-messaging-eventhubs</artifactId>
         </dependency>
@@ -142,9 +150,25 @@
                             org.wso2.am.analytics.publisher.util.*;version="${project.version}",
                             org.wso2.am.analytics.publisher.properties.*;version="${project.version}",
                         </Export-Package>
+                        <Embed-Dependency>
+                            moesifapi;scope=compile|runtime;inline=false,
+                            unirest-java;scope=compile|runtime;inline=false,
+                            httpasyncclient;scope=compile|runtime;inline=false,
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
                         <Private-Package>
+                            com.moesif.api.*;version="${moesif.api.version}",
+                            com.mashape.unirest.*,
+                            org.apache.http.impl.nio.*,
+                            org.apache.http.nio.*,
                         </Private-Package>
                         <Import-Package>
+                            <!-- Exclude embedded packages from import -->
+                            !com.moesif.api.*,
+                            !com.mashape.unirest.*,
+                            !org.apache.http.impl.nio.*,
+                            !org.apache.http.nio.*,
+
                             com.google.gson.*;version="${gson.import.version.range}",
                             com.google.gson.annotations.*;version="${google.gson.import.version.range}",
                             com.azure.core.credential.*;version="${azure.core.import.version.range}",
@@ -157,7 +181,7 @@
                             ua_parser.*;version="${ua_parser.import.version.range}",
                             com.microsoft.azure.proton.transport.*;version="${azure-qpid-proton-j-extensions.import.version.range}",
                             org.apache.http.*,
-                            com.moesif.api.*;resolution:=optional
+                            *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                         <Include-Resource>

--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -157,10 +157,6 @@
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Private-Package>
-                            com.moesif.api.*;version="${moesif.api.version}",
-                            com.mashape.unirest.*,
-                            org.apache.http.impl.nio.*,
-                            org.apache.http.nio.*,
                         </Private-Package>
                         <Import-Package>
                             <!-- Exclude embedded packages from import -->

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
@@ -9,6 +9,8 @@ import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.util.Constants;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -21,6 +23,20 @@ public abstract class AbstractMoesifClient {
      * Publish method is responsible for publishing events to Moesif.
      */
     public abstract void publish(MetricEventBuilder builder) throws MetricReportingException;
+    public void publishBatch(List<MetricEventBuilder> builders) {
+        if (builders == null || builders.isEmpty()) {
+            return;
+        }
+
+        List<Map<String, Object>> events = new ArrayList<>();
+        for (MetricEventBuilder builder : builders) {
+            try {
+                this.publish(builder);
+            } catch (MetricReportingException e) {
+                log.error("Builder instance is not duly filled. Event building failed", e);
+            }
+        }
+    }
 
     public abstract EventModel buildEventResponse(Map<String, Object> data)
             throws IOException, MetricReportingException;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
@@ -1,0 +1,40 @@
+package org.wso2.am.analytics.publisher.client;
+
+import com.moesif.api.models.EventModel;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.util.Constants;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Abstract class representing a Moesif client for publishing events and building event responses.
+ */
+public abstract class AbstractMoesifClient {
+    protected final Logger log = LogManager.getLogger(AbstractMoesifClient.class);
+
+    /**
+     * Publish method is responsible for publishing events to Moesif.
+     */
+    public abstract void publish(MetricEventBuilder builder) throws MetricReportingException;
+
+    public abstract EventModel buildEventResponse(Map<String, Object> data)
+            throws IOException, MetricReportingException;
+
+    protected static void populateHeaders(Map<String, Object> data, Map<String, String> reqHeaders,
+            Map<String, String> rspHeaders) {
+        reqHeaders.put(Constants.MOESIF_USER_AGENT_KEY,
+                (String) data.getOrDefault(Constants.USER_AGENT_HEADER, Constants.UNKNOWN_VALUE));
+        reqHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.MOESIF_CONTENT_TYPE_HEADER);
+
+        rspHeaders.put("Vary", "Accept-Encoding");
+        rspHeaders.put("Pragma", "no-cache");
+        rspHeaders.put("Expires", "-1");
+        rspHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, "application/json; charset=utf-8");
+        rspHeaders.put("Cache-Control", "no-cache");
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.am.analytics.publisher.client;
 
 import com.moesif.api.models.EventModel;
@@ -9,6 +26,7 @@ import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.util.Constants;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -33,10 +51,23 @@ public abstract class AbstractMoesifClient {
                 (String) data.getOrDefault(Constants.USER_AGENT_HEADER, Constants.UNKNOWN_VALUE));
         reqHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.MOESIF_CONTENT_TYPE_HEADER);
 
-        rspHeaders.put("Vary", "Accept-Encoding");
-        rspHeaders.put("Pragma", "no-cache");
-        rspHeaders.put("Expires", "-1");
+        rspHeaders.put(Constants.VARY_HEADER, "Accept-Encoding");
+        rspHeaders.put(Constants.PRAGMA_HEADER, "no-cache");
+        rspHeaders.put(Constants.EXPIRES_HEADER, "-1");
         rspHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, "application/json; charset=utf-8");
-        rspHeaders.put("Cache-Control", "no-cache");
+        rspHeaders.put(Constants.CACHE_CONTROL_HEADER, "no-cache");
+    }
+
+    protected List<EventModel> buidEventsfromBuilders(List<MetricEventBuilder> builders) {
+        List<EventModel> events = new ArrayList<>();
+        for (MetricEventBuilder builder : builders) {
+            try {
+                Map<String, Object> event = builder.build();
+                events.add(this.buildEventResponse(event));
+            } catch (MetricReportingException | IOException e) {
+                log.error("Builder instance is not duly filled. Event building failed", e);
+            }
+        }
+        return events;
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
@@ -51,11 +51,11 @@ public abstract class AbstractMoesifClient {
                 (String) data.getOrDefault(Constants.USER_AGENT_HEADER, Constants.UNKNOWN_VALUE));
         reqHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.MOESIF_CONTENT_TYPE_HEADER);
 
-        rspHeaders.put(Constants.VARY_HEADER, "Accept-Encoding");
-        rspHeaders.put(Constants.PRAGMA_HEADER, "no-cache");
-        rspHeaders.put(Constants.EXPIRES_HEADER, "-1");
-        rspHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, "application/json; charset=utf-8");
-        rspHeaders.put(Constants.CACHE_CONTROL_HEADER, "no-cache");
+        rspHeaders.put(Constants.VARY_HEADER, Constants.ACCEPT_ENCODING_VALUE);
+        rspHeaders.put(Constants.PRAGMA_HEADER, Constants.NO_CACHE_VALUE);
+        rspHeaders.put(Constants.EXPIRES_HEADER, Constants.EXPIRES_VALUE);
+        rspHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.APPLICATION_JSON_UTF8_VALUE);
+        rspHeaders.put(Constants.CACHE_CONTROL_HEADER, Constants.NO_CACHE_VALUE);
     }
 
     protected List<EventModel> buidEventsfromBuilders(List<MetricEventBuilder> builders) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
@@ -9,7 +9,6 @@ import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.util.Constants;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -23,20 +22,7 @@ public abstract class AbstractMoesifClient {
      * Publish method is responsible for publishing events to Moesif.
      */
     public abstract void publish(MetricEventBuilder builder) throws MetricReportingException;
-    public void publishBatch(List<MetricEventBuilder> builders) {
-        if (builders == null || builders.isEmpty()) {
-            return;
-        }
-
-        List<Map<String, Object>> events = new ArrayList<>();
-        for (MetricEventBuilder builder : builders) {
-            try {
-                this.publish(builder);
-            } catch (MetricReportingException e) {
-                log.error("Builder instance is not duly filled. Event building failed", e);
-            }
-        }
-    }
+    public abstract void publishBatch(List<MetricEventBuilder> builders);
 
     public abstract EventModel buildEventResponse(Map<String, Object> data)
             throws IOException, MetricReportingException;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -41,7 +41,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -41,10 +41,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -48,10 +48,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Moesif Client is responsible for sending events to
- * Moesif Analytics Dashboard.
+ * This client is responsible for publishing events from choreo backend
+ * to Moesif Analytics dahsboard
  */
-public class MoesifClient {
+public class MoesifClient extends AbstractMoesifClient {
     private final Logger log = LogManager.getLogger(MoesifClient.class);
     private final MoesifKeyRetriever keyRetriever;
 
@@ -83,6 +83,7 @@ public class MoesifClient {
      * publish method is responsible for checking the availability of relevant moesif key
      * and initiating moesif client sdk.
      */
+    @Override
     public void publish(MetricEventBuilder builder) throws MetricReportingException {
         Map<String, Object> event = builder.build();
         ConcurrentHashMap<String, String> orgIDMoesifKeyMap = keyRetriever.getMoesifKeyMap();
@@ -155,7 +156,8 @@ public class MoesifClient {
         }
     }
 
-    private EventModel buildEventResponse(Map<String, Object> data) throws IOException, MetricReportingException {
+    @Override
+    public EventModel buildEventResponse(Map<String, Object> data) throws IOException, MetricReportingException {
         Map<String, String> reqHeaders = new HashMap<>();
         Map<String, String> rspHeaders = new HashMap<>();
 
@@ -250,18 +252,5 @@ public class MoesifClient {
         eventModel.setCompanyId(null);
 
         return eventModel;
-    }
-
-    private static void populateHeaders(Map<String, Object> data, Map<String, String> reqHeaders,
-            Map<String, String> rspHeaders) {
-        reqHeaders.put(Constants.MOESIF_USER_AGENT_KEY,
-                (String) data.getOrDefault(Constants.USER_AGENT_HEADER, Constants.UNKNOWN_VALUE));
-        reqHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.MOESIF_CONTENT_TYPE_HEADER);
-
-        rspHeaders.put("Vary", "Accept-Encoding");
-        rspHeaders.put("Pragma", "no-cache");
-        rspHeaders.put("Expires", "-1");
-        rspHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, "application/json; charset=utf-8");
-        rspHeaders.put("Cache-Control", "no-cache");
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -42,7 +42,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -328,7 +333,6 @@ public class MoesifClient extends AbstractMoesifClient {
             try {
                 Map<String, Object> event = builder.build();
 
-                // Apply environment filtering
                 if (isValidForEnvironment(event, userSelectedEnvironment)) {
                     validEvents.add(buildEventResponse(event));
                 } else {
@@ -388,7 +392,6 @@ public class MoesifClient extends AbstractMoesifClient {
         LinkedHashMap properties = (LinkedHashMap) event.get(Constants.PROPERTIES);
         String eventEnvironment = (String) properties.get(Constants.DEPLOYMENT_TYPE);
 
-        // Skip non-production events when user selected production environment
         return !(Constants.PRODUCTION.equals(userSelectedEnvironment) &&
                 !Constants.PRODUCTION.equals(eventEnvironment));
     }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -44,6 +44,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -154,6 +155,11 @@ public class MoesifClient extends AbstractMoesifClient {
         } catch (IOException e) {
             log.error("Analytics event sending failed. Event will be dropped", e);
         }
+    }
+
+    @Override
+    public void publishBatch(List<MetricEventBuilder> builders) {
+
     }
 
     @Override

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -1,0 +1,198 @@
+package org.wso2.am.analytics.publisher.client;
+
+import com.moesif.api.MoesifAPIClient;
+import com.moesif.api.controllers.APIController;
+import com.moesif.api.http.client.APICallBack;
+import com.moesif.api.http.client.HttpContext;
+import com.moesif.api.http.response.HttpResponse;
+import com.moesif.api.models.EventModel;
+import com.moesif.api.models.EventRequestBuilder;
+import com.moesif.api.models.EventRequestModel;
+import com.moesif.api.models.EventResponseBuilder;
+import com.moesif.api.models.EventResponseModel;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
+import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifMicroserviceConstants;
+import org.wso2.am.analytics.publisher.util.Constants;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Simple Moesif client implementation for publishing events from APIM
+ * to Moesif analytics dashboard.
+ */
+public class SimpleMoesifClient extends AbstractMoesifClient {
+    private final MoesifAPIClient moesifAPIClient;
+    private final APIController api;
+
+    public SimpleMoesifClient(String key) {
+        this.moesifAPIClient = new MoesifAPIClient(key);
+        this.api = moesifAPIClient.getAPI();
+    }
+
+    @Override
+    public void publish(MetricEventBuilder builder) throws MetricReportingException {
+        Map<String, Object> event = builder.build();
+
+        APICallBack<HttpResponse> callBack = new APICallBack<HttpResponse>() {
+            public void onSuccess(HttpContext context, HttpResponse response) {
+                int statusCode = context.getResponse().getStatusCode();
+                if (statusCode == 200 || statusCode == 201 || statusCode == 202 || statusCode == 204) {
+                    log.debug("Event successfully published.");
+                } else if (statusCode >= 400 && statusCode < 500) {
+                    log.error("Event publishing failed. Moesif returned {}.",
+                            String.valueOf(statusCode).replaceAll("[\r\n]", ""));
+                } else {
+                    log.error("Event publishing failed. Retrying.");
+                    doRetry(builder);
+                }
+            }
+
+            public void onFailure(HttpContext context, Throwable error) {
+                int statusCode = context.getResponse().getStatusCode();
+
+                if (statusCode >= 400 && statusCode < 500) {
+                    log.error("Event publishing failed. Moesif returned {}.",
+                            String.valueOf(statusCode).replaceAll("[\r\n]", ""));
+                } else if (error != null) {
+                    log.error("Event publishing failed. Event publishing failed.");
+                } else {
+                    log.error("Event publishing failed. Retrying.");
+                    doRetry(builder);
+                }
+            }
+        };
+        try {
+            this.api.createEventAsync(buildEventResponse(event), callBack);
+        } catch (IOException e) {
+            log.error("Analytics event sending failed. Event will be dropped", e);
+        }
+    }
+
+    @Override
+    public EventModel buildEventResponse(Map<String, Object> data) throws IOException, MetricReportingException {
+        Map<String, String> reqHeaders = new HashMap<>();
+        Map<String, String> rspHeaders = new HashMap<>();
+
+        populateHeaders(data, reqHeaders, rspHeaders);
+
+        EventRequestModel eventReq;
+        EventResponseModel eventRsp;
+        EventModel eventModel = new EventModel();
+        String modifiedUserName;
+
+        Map<String, String> metadata = new HashMap<>();
+        populateMetadata(data, metadata);
+
+        if (!data.containsKey(Constants.ERROR_CODE)) {
+            final String userIP = (String) data.get(Constants.USER_IP);
+            final String userName = (String) data.get(Constants.USER_NAME);
+            final String apiContext = (String) ((LinkedHashMap) data.get(Constants.PROPERTIES)).get(
+                    Constants.API_CONTEXT);
+            final String apiResourceTemplate = (String) data.get(Constants.API_RESOURCE_TEMPLATE);
+            final long responseLatency = (long) data.get(Constants.RESPONSE_LATENCY);
+
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
+            Instant requestTimestamp = Instant.from(
+                    dateTimeFormatter.parse((String) data.get(Constants.REQUEST_TIMESTAMP)));
+            Instant responseTimestamp = requestTimestamp.plusMillis(responseLatency);
+
+            LinkedHashMap properties = (LinkedHashMap) data.get(Constants.PROPERTIES);
+            String gwURL = (String) properties.get(Constants.GATEWAY_URL);
+            String uri = apiContext + apiResourceTemplate;
+            if (gwURL != null) {
+                uri = gwURL;
+            }
+
+            eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(uri)
+                    .verb((String) data.get(Constants.API_METHOD)).apiVersion((String) data.get(Constants.API_VERSION))
+                    .ipAddress(userIP).headers(reqHeaders).build();
+
+            eventRsp = new EventResponseBuilder().time(Date.from(responseTimestamp))
+                    .status((int) data.get(Constants.TARGET_RESPONSE_CODE)).headers(rspHeaders).build();
+
+            if (userName.contains("@carbon.super")) {
+                modifiedUserName = userName.replace("@carbon.super", "");
+            } else {
+                modifiedUserName = userName;
+            }
+
+        } else {
+            LinkedHashMap properties = (LinkedHashMap) data.get(Constants.PROPERTIES);
+
+            modifiedUserName = (String) data.get(Constants.API_CREATION);
+
+            String apiContext = (String) ((LinkedHashMap) data.get(Constants.PROPERTIES)).get(Constants.API_CONTEXT);
+            String gwURL = (String) properties.get(Constants.GATEWAY_URL);
+            String apiResourceTemplate = (String) data.get(Constants.API_RESOURCE_TEMPLATE);
+            String uri = apiContext + apiResourceTemplate;
+
+            if (gwURL != null) {
+                uri = gwURL;
+            }
+
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
+            Instant requestTimestamp = Instant.from(
+                    dateTimeFormatter.parse((String) data.get(Constants.REQUEST_TIMESTAMP)));
+
+            eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(uri)
+                    .verb((String) data.get(Constants.API_METHOD)).apiVersion((String) data.get(Constants.API_VERSION))
+                    .headers(reqHeaders).build();
+
+            Date dateNow = Date.from(Instant.now());
+
+            eventRsp = new EventResponseBuilder().time(dateNow).status((int) data.get(Constants.PROXY_RESPONSE_CODE))
+                    .headers(rspHeaders).build();
+        }
+
+        eventModel.setRequest(eventReq);
+        eventModel.setResponse(eventRsp);
+        eventModel.setUserId(modifiedUserName);
+        eventModel.setMetadata(metadata);
+        eventModel.setCompanyId(null);
+
+        return eventModel;
+    }
+
+    private void doRetry(MetricEventBuilder builder) {
+        Integer currentAttempt = MoesifClientContextHolder.PUBLISH_ATTEMPTS.get();
+
+        if (currentAttempt > 0) {
+            currentAttempt -= 1;
+            MoesifClientContextHolder.PUBLISH_ATTEMPTS.set(currentAttempt);
+            try {
+                Thread.sleep(MoesifMicroserviceConstants.TIME_TO_WAIT_PUBLISH);
+                publish(builder);
+            } catch (MetricReportingException e) {
+                log.error("Failing retry attempt at Moesif client", e);
+            } catch (InterruptedException e) {
+                log.error("Failing retry attempt at Moesif client", e);
+            }
+        } else if (currentAttempt == 0) {
+            log.error("Failed all retrying attempts. Event will be dropped");
+        }
+    }
+
+    private void populateMetadata(Map<String, Object> data, Map<String, String> metadata) {
+        Set<String> requiredKeys = new HashSet<>(Arrays.asList(
+                Constants.API_ID, Constants.API_METHOD, Constants.API_NAME,
+                Constants.API_TYPE, Constants.APPLICATION_ID, Constants.APPLICATION_NAME, Constants.APPLICATION_OWNER,
+                Constants.BACKEND_LATENCY, Constants.GATEWAY_TYPE, Constants.KEY_TYPE, Constants.EVENT_TYPE,
+                Constants.DESTINATION, Constants.ERROR_CODE, Constants.ERROR_MESSAGE, Constants.ERROR_TYPE
+        ));
+
+        data.entrySet().stream().filter(entry -> requiredKeys.contains(entry.getKey()))
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> metadata.put(entry.getKey(), String.valueOf(entry.getValue())));
+
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -72,7 +72,7 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             }
         };
         try {
-            this.api.createEventAsync(buildEventResponse(event), callBack);
+            api.createEventAsync(buildEventResponse(event), callBack);
         } catch (IOException e) {
             log.error("Analytics event sending failed. Event will be dropped", e);
         }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -36,7 +36,6 @@ import org.wso2.am.analytics.publisher.util.HttpStatusHelper;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -18,7 +18,13 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Simple Moesif client implementation for publishing events from APIM
@@ -41,7 +47,8 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             /**
              * Callback method invoked when the event publishing request receives a response from Moesif.
              * This method handles the response based on the HTTP status code:
-             *   If the status code is 200, 201, 202, or 204, the event is considered successfully published and a debug log is written.
+             *   If the status code is 200, 201, 202, or 204, the event is considered successfully
+             *   published and a debug log is written.
              *   If the status code is in the 4xx range, it logs an error indicating a client-side failure.
              *   For all other status codes (typically 5xx or unexpected values), it logs the error and initiates a
              *   retry using {@code doRetry(builder)}.
@@ -73,7 +80,8 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
              * retryable failure (e.g., server error or network timeout) and attempts to retry the event publishing.
              *
              * @param context the HTTP context containing the response from the Moesif API
-             * @param error   the Throwable indicating the cause of the failure, or {@code null} if no exception occurred
+             * @param error   the Throwable indicating the cause of the failure, or {@code null}
+             *               if no exception occurred
              */
             public void onFailure(HttpContext context, Throwable error) {
                 int statusCode = context.getResponse().getStatusCode();

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/GenericInputValidator.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/GenericInputValidator.java
@@ -233,6 +233,57 @@ public class GenericInputValidator {
                     new AbstractMap.SimpleImmutableEntry<>(API_RESOURCE_TEMPLATE, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(API_CONTEXT, String.class))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    private static final Map<String, Class> moesifResponseEventSchema = Stream.of(
+                    new AbstractMap.SimpleImmutableEntry<>(REQUEST_TIMESTAMP, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(CORRELATION_ID, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(KEY_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_ID, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_NAME, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_VERSION, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_CREATION, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_METHOD, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_RESOURCE_TEMPLATE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_CREATOR_TENANT_DOMAIN, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(DESTINATION, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(APPLICATION_ID, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(APPLICATION_NAME, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(APPLICATION_OWNER, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(GATEWAY_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(USER_AGENT_HEADER, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(USER_NAME, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(PROXY_RESPONSE_CODE, Integer.class),
+                    new AbstractMap.SimpleImmutableEntry<>(TARGET_RESPONSE_CODE, Integer.class),
+                    new AbstractMap.SimpleImmutableEntry<>(RESPONSE_CACHE_HIT, Boolean.class),
+                    new AbstractMap.SimpleImmutableEntry<>(RESPONSE_LATENCY, Long.class),
+                    new AbstractMap.SimpleImmutableEntry<>(BACKEND_LATENCY, Long.class),
+                    new AbstractMap.SimpleImmutableEntry<>(REQUEST_MEDIATION_LATENCY, Long.class),
+                    new AbstractMap.SimpleImmutableEntry<>(RESPONSE_MEDIATION_LATENCY, Long.class),
+                    new AbstractMap.SimpleImmutableEntry<>(USER_IP, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(PROPERTIES, LinkedHashMap.class))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    private static final Map<String, Class> moesifFaultEventSchema = Stream.of(
+                    new AbstractMap.SimpleImmutableEntry<>(REQUEST_TIMESTAMP, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(CORRELATION_ID, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(KEY_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(ERROR_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(ERROR_CODE, Integer.class),
+                    new AbstractMap.SimpleImmutableEntry<>(ERROR_MESSAGE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_ID, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_NAME, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_VERSION, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_CREATION, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_METHOD, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_RESOURCE_TEMPLATE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_CREATOR_TENANT_DOMAIN, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(APPLICATION_ID, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(APPLICATION_NAME, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(APPLICATION_OWNER, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(GATEWAY_TYPE, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(TARGET_RESPONSE_CODE, Integer.class),
+                    new AbstractMap.SimpleImmutableEntry<>(PROPERTIES, LinkedHashMap.class))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     private static final List<String> configProperties = new ArrayList<>();
 
     private GenericInputValidator() {
@@ -257,6 +308,10 @@ public class GenericInputValidator {
                 return elkResponseEventSchema;
             case ELK_ERROR:
                 return elkFaultEventSchema;
+            case MOESIF_RESPONSE:
+                return moesifResponseEventSchema;
+            case MOESIF_ERROR:
+                return moesifFaultEventSchema;
             default:
                 return new HashMap<>();
         }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/GenericInputValidator.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/GenericInputValidator.java
@@ -282,6 +282,7 @@ public class GenericInputValidator {
                     new AbstractMap.SimpleImmutableEntry<>(APPLICATION_OWNER, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(GATEWAY_TYPE, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(TARGET_RESPONSE_CODE, Integer.class),
+                    new AbstractMap.SimpleImmutableEntry<>(PROXY_RESPONSE_CODE, Integer.class),
                     new AbstractMap.SimpleImmutableEntry<>(PROPERTIES, LinkedHashMap.class))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     private static final List<String> configProperties = new ArrayList<>();

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricSchema.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricSchema.java
@@ -29,5 +29,7 @@ public enum MetricSchema {
     ELK_RESPONSE,
     ELK_ERROR,
     LATENCY,
-    PAYLOAD
+    PAYLOAD,
+    MOESIF_RESPONSE,
+    MOESIF_ERROR,
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
@@ -19,7 +19,9 @@ package org.wso2.am.analytics.publisher.reporter.moesif;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.wso2.am.analytics.publisher.client.AbstractMoesifClient;
 import org.wso2.am.analytics.publisher.client.MoesifClient;
+import org.wso2.am.analytics.publisher.client.SimpleMoesifClient;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsThreadFactory;
 import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
@@ -40,10 +42,17 @@ public class EventQueue {
     private final ExecutorService publisherExecutorService;
     private final AtomicInteger failureCount;
 
+    public EventQueue(int queueSize, int workerThreadCount, String key) {
+        this(queueSize, workerThreadCount, new SimpleMoesifClient(key));
+    }
+
     public EventQueue(int queueSize, int workerThreadCount, MoesifKeyRetriever moesifKeyRetriever) {
+        this(queueSize, workerThreadCount, new MoesifClient(moesifKeyRetriever));
+    }
+
+    public EventQueue(int queueSize, int workerThreadCount, AbstractMoesifClient moesifClient) {
         publisherExecutorService = Executors.newFixedThreadPool(workerThreadCount,
                 new DefaultAnalyticsThreadFactory("Queue-Worker"));
-        MoesifClient moesifClient = new MoesifClient(moesifKeyRetriever);
         eventQueue = new LinkedBlockingQueue<>(queueSize);
         failureCount = new AtomicInteger(0);
         for (int i = 0; i < workerThreadCount; i++) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifCounterMetric.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifCounterMetric.java
@@ -69,10 +69,10 @@ public class MoesifCounterMetric implements CounterMetric {
             case RESPONSE:
             default:
                 return new MoesifMetricEventBuilder(
-                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.RESPONSE));
+                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.MOESIF_RESPONSE));
             case ERROR:
                 return new MoesifMetricEventBuilder(
-                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.ERROR));
+                        GenericInputValidator.getInstance().getEventProperties(MetricSchema.MOESIF_ERROR));
             case CHOREO_RESPONSE:
                 return new MoesifMetricEventBuilder(
                         GenericInputValidator.getInstance().getEventProperties(MetricSchema.CHOREO_RESPONSE));

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifMetricEventBuilder.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifMetricEventBuilder.java
@@ -36,7 +36,7 @@ public class MoesifMetricEventBuilder extends AbstractMetricEventBuilder {
     private Boolean isBuilt = false;
 
     public MoesifMetricEventBuilder() {
-        requiredAttributes = GenericInputValidator.getInstance().getEventProperties(MetricSchema.RESPONSE);
+        requiredAttributes = GenericInputValidator.getInstance().getEventProperties(MetricSchema.MOESIF_RESPONSE);
         eventMap = new HashMap<>();
     }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/ParallelQueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/ParallelQueueWorker.java
@@ -24,6 +24,8 @@ import org.wso2.am.analytics.publisher.client.AbstractMoesifClient;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 
 /**
@@ -33,24 +35,53 @@ public class ParallelQueueWorker implements Runnable {
     private static final Logger log = LogManager.getLogger(ParallelQueueWorker.class);
     private BlockingQueue<MetricEventBuilder> eventQueue;
     private AbstractMoesifClient client;
+    private final int batchSize = 50;
+    private final long batchTimeoutMs = 2000;
 
     public ParallelQueueWorker(BlockingQueue<MetricEventBuilder> queue, AbstractMoesifClient moesifClient) {
         this.eventQueue = queue;
         this.client = moesifClient;
     }
 
-    public void run() {
+    /**
+     * Continuously runs a worker thread that processes analytics events in batches from a blocking queue.
+     * <p>
+     * The method polls the {@code eventQueue} at fixed intervals (100ms) for new {@code MetricEventBuilder} events.
+     * Events are collected into a batch and processed when either:
+     * <ul>
+     *   <li>The batch reaches the configured {@code batchSize}</li>
+     *   <li>The elapsed time since the last batch processing exceeds {@code batchTimeoutMs}</li>
+     * </ul>
+     * Once either condition is met, the collected batch is sent using {@code processBatch}, and the timer is reset.
+     * <p>
+     * If the thread is interrupted, it exits gracefully by setting the interrupt flag. Any other exception
+     * during processing is logged, and the affected events will be dropped.
+     *
+     * This method is intended to be executed in a dedicated thread via an {@code ExecutorService} or similar mechanism.
+     */
 
+    public void run() {
+        List<MetricEventBuilder> batch = new ArrayList<>(batchSize);
+        long lastBatchTime = System.currentTimeMillis();
         while (true) {
             MetricEventBuilder eventBuilder;
             try {
-                eventBuilder = eventQueue.take();
+
+                eventBuilder = eventQueue.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS);
                 if (eventBuilder != null) {
-                    client.publish(eventBuilder);
+                    batch.add(eventBuilder);
                 }
-            } catch (MetricReportingException e) {
-                log.error("Builder instance is not duly filled. Event building failed", e);
-                continue;
+
+                long currrentBatchTime = System.currentTimeMillis();
+                boolean shouldSendBatch = batch.size() >= batchSize ||
+                        (currrentBatchTime - lastBatchTime) >= batchTimeoutMs;
+
+                if (shouldSendBatch) {
+                    log.debug("Sending batch of {} events", batch.size());
+                    processBatch(new ArrayList<>(batch));
+                    batch.clear();
+                    lastBatchTime = currrentBatchTime;
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
@@ -58,5 +89,25 @@ public class ParallelQueueWorker implements Runnable {
             }
         }
     }
+    private void processBatch(List<MetricEventBuilder> batch) {
+        if (batch.isEmpty()) {
+            return;
+        }
+
+        try {
+            if (batch.size() == 1) {
+                client.publish(batch.get(0));
+            } else {
+                client.publishBatch(batch);
+            }
+            log.debug("Successfully processed batch of {} events", batch.size());
+        } catch (MetricReportingException e) {
+            log.error("Failed to process batch of {} events", batch.size(), e);
+        } catch (Exception e) {
+            log.error("Unexpected error processing batch", e);
+        }
+    }
+
+
 
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/ParallelQueueWorker.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/ParallelQueueWorker.java
@@ -20,23 +20,21 @@ package org.wso2.am.analytics.publisher.reporter.moesif;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.wso2.am.analytics.publisher.client.MoesifClient;
+import org.wso2.am.analytics.publisher.client.AbstractMoesifClient;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
-import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
 
 import java.util.concurrent.BlockingQueue;
 
 /**
- * Will dequeue the events from queues and send then to the moesif client {@link MoesifClient}.
+ * Will dequeue the events from queues and send then to the moesif client.
  */
 public class ParallelQueueWorker implements Runnable {
     private static final Logger log = LogManager.getLogger(ParallelQueueWorker.class);
     private BlockingQueue<MetricEventBuilder> eventQueue;
-    private MoesifKeyRetriever keyRetriever;
-    private MoesifClient client;
+    private AbstractMoesifClient client;
 
-    public ParallelQueueWorker(BlockingQueue<MetricEventBuilder> queue, MoesifClient moesifClient) {
+    public ParallelQueueWorker(BlockingQueue<MetricEventBuilder> queue, AbstractMoesifClient moesifClient) {
         this.eventQueue = queue;
         this.client = moesifClient;
     }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -125,4 +125,9 @@ public class Constants {
     public static final String GATEWAY_URL = "x-original-gw-url";
     public static final String DEPLOYMENT_TYPE = "deployment-type";
     public static final String PRODUCTION = "PRODUCTION";
+    public static final String VARY_HEADER = "Vary";
+    public static final String PRAGMA_HEADER = "Pragma";
+    public static final String EXPIRES_HEADER = "Expires";
+    public static final String CACHE_CONTROL_HEADER = "Cache-Control";
+
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -129,5 +129,9 @@ public class Constants {
     public static final String PRAGMA_HEADER = "Pragma";
     public static final String EXPIRES_HEADER = "Expires";
     public static final String CACHE_CONTROL_HEADER = "Cache-Control";
+    public static final String ACCEPT_ENCODING_VALUE = "Accept-Encoding";
+    public static final String NO_CACHE_VALUE = "no-cache";
+    public static final String EXPIRES_VALUE = "-1";
+    public static final String APPLICATION_JSON_UTF8_VALUE = "application/json; charset=utf-8";
 
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
@@ -18,7 +18,11 @@
 package org.wso2.am.analytics.publisher.util;
 
 import java.util.Set;
-
+/**
+ * Utility class for handling HTTP status codes.
+ * Provides methods to determine the type of HTTP response (success, client error, server error)
+ * and whether a request should be retried based on the status code.
+ */
 public class HttpStatusHelper {
     // HTTP Status Code Ranges
     public static final int SUCCESS_RANGE_START = 200;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
@@ -1,0 +1,60 @@
+package org.wso2.am.analytics.publisher.util;
+
+import java.util.Set;
+
+public class HttpStatusHelper {
+    // HTTP Status Code Ranges
+    public static final int SUCCESS_RANGE_START = 200;
+    public static final int SUCCESS_RANGE_END = 299;
+    public static final int CLIENT_ERROR_RANGE_START = 400;
+    public static final int CLIENT_ERROR_RANGE_END = 499;
+    public static final int SERVER_ERROR_RANGE_START = 500;
+    public static final int SERVER_ERROR_RANGE_END = 599;
+
+    private static final Set<Integer> RETRYABLE_CLIENT_ERRORS = Set.of(408, 429);
+    /**
+     * Checks if the HTTP status code indicates a successful response.
+     * Success range: 200-299
+     *
+     * @param statusCode HTTP status code to check
+     * @return true if status code is in success range (2xx)
+     */
+    public static boolean isSuccess(int statusCode) {
+        return statusCode >= SUCCESS_RANGE_START &&
+                statusCode <= SUCCESS_RANGE_END;
+    }
+
+    /**
+     * Checks if the HTTP status code indicates a client error.
+     * Client error range: 400-499
+     *
+     * @param statusCode HTTP status code to check
+     * @return true if status code is in client error range (4xx)
+     */
+    public static boolean isClientError(int statusCode) {
+        return statusCode >= CLIENT_ERROR_RANGE_START &&
+                statusCode < CLIENT_ERROR_RANGE_END;
+    }
+
+    /**
+     * Checks if the HTTP status code indicates a server error.
+     * Server error range: 500-599
+     *
+     * @param statusCode HTTP status code to check
+     * @return true if status code is in server error range (5xx)
+     */
+    public static boolean isServerError(int statusCode) {
+        return statusCode >= SERVER_ERROR_RANGE_START &&
+                statusCode < SERVER_ERROR_RANGE_END;
+    }
+
+    /**
+     * Determine if the request should be retried based on status code.
+     * Retryable conditions: server errors (5xx) and specific client errors (408, 429).
+     * @param statusCode HTTP status code
+     * @return true if request should be retried
+     */
+    public static boolean shouldRetry(int statusCode) {
+        return isServerError(statusCode) || RETRYABLE_CLIENT_ERRORS.contains(statusCode);
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.am.analytics.publisher.util;
 
 import java.util.Set;

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,16 @@
                 <version>${moesif.api.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.moesif.unirest</groupId>
+                <artifactId>unirest-java</artifactId>
+                <version>${moesif.unirest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>${apache.httpcomponents.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-messaging-eventhubs</artifactId>
                 <version>${azure.messaging.evenhub.version}</version>
@@ -285,6 +295,8 @@
     <properties>
         <gson.import.version.range>[2.0.0, 3.0.0)</gson.import.version.range>
         <moesif.api.version>1.7.4</moesif.api.version>
+        <moesif.unirest.version>1.0.8</moesif.unirest.version>
+        <apache.httpcomponents.version>4.0.2</apache.httpcomponents.version>
         <azure.messaging.evenhub.version>5.3.1</azure.messaging.evenhub.version>
         <gson.version>2.11.0</gson.version>
         <slf4j.version>1.7.2</slf4j.version>


### PR DESCRIPTION
## Purpose
- To **enable Moesif analytics support in WSO2 API Manager** by identifying and addressing the current gap in integration, thereby allowing API analytics data to be published directly to the Moesif dashboard.
- Related to : [wso2/api-manager/issues/3968](https://github.com/wso2/api-manager/issues/3968)

### Approach
- Introduced a new `SimpleMoesifClient` class to enable analytics event publishing to Moesif from wso2 api manager.
- Implemented batch event publishing to improve performance and efficiency.
