### PR TITLE
Improve to support java8

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/HttpStatusHelper.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.am.analytics.publisher.util;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 /**
  * Utility class for handling HTTP status codes.
@@ -32,7 +35,8 @@ public class HttpStatusHelper {
     public static final int SERVER_ERROR_RANGE_START = 500;
     public static final int SERVER_ERROR_RANGE_END = 599;
 
-    private static final Set<Integer> RETRYABLE_CLIENT_ERRORS = Set.of(408, 429);
+    private static final Set<Integer> RETRYABLE_CLIENT_ERRORS =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(408, 429)));
     /**
      * Checks if the HTTP status code indicates a successful response.
      * Success range: 200-299


### PR DESCRIPTION
This pull request makes a minor update to the way retryable client error codes are defined in the `HttpStatusHelper` class. The change improves compatibility by replacing the use of `Set.of` with a more broadly supported approach.

* Refactored the initialization of `RETRYABLE_CLIENT_ERRORS` to use `Collections.unmodifiableSet(new HashSet<>(Arrays.asList(...)))` instead of `Set.of(...)` for better compatibility with older Java versions.
* Added missing imports (`Arrays`, `Collections`, `HashSet`) required for the new initialization method.