### PR TITLE
Improve to support header based analytics

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/AbstractMoesifClient.java
@@ -51,11 +51,21 @@ public abstract class AbstractMoesifClient {
                 (String) data.getOrDefault(Constants.USER_AGENT_HEADER, Constants.UNKNOWN_VALUE));
         reqHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.MOESIF_CONTENT_TYPE_HEADER);
 
+        if (data.containsKey(Constants.REQUEST_HEADERS) && data.get(Constants.REQUEST_HEADERS) != null) {
+            Map<String, String> headers = (Map<String, String>) data.get(Constants.REQUEST_HEADERS);
+            reqHeaders.putAll(headers);
+        }
+
         rspHeaders.put(Constants.VARY_HEADER, Constants.ACCEPT_ENCODING_VALUE);
         rspHeaders.put(Constants.PRAGMA_HEADER, Constants.NO_CACHE_VALUE);
         rspHeaders.put(Constants.EXPIRES_HEADER, Constants.EXPIRES_VALUE);
         rspHeaders.put(Constants.MOESIF_CONTENT_TYPE_KEY, Constants.APPLICATION_JSON_UTF8_VALUE);
         rspHeaders.put(Constants.CACHE_CONTROL_HEADER, Constants.NO_CACHE_VALUE);
+
+        if (data.containsKey(Constants.RESPONSE_HEADERS) && data.get(Constants.RESPONSE_HEADERS) != null) {
+            Map<String, String> headers = (Map<String, String>) data.get(Constants.RESPONSE_HEADERS);
+            rspHeaders.putAll(headers);
+        }
     }
 
     protected List<EventModel> buildEventsFromBuilders(List<MetricEventBuilder> builders) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -142,7 +142,6 @@ public class MoesifClient extends AbstractMoesifClient {
         EventResponseModel eventRsp;
         EventModel eventModel = new EventModel();
         String modifiedUserName;
-
         if (!data.containsKey(Constants.ERROR_CODE)) {
             final String userIP = (String) data.get(Constants.USER_IP);
             final String userName = (String) data.get(Constants.USER_NAME);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -59,6 +59,11 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
         this.api = moesifAPIClient.getAPI();
     }
 
+    public SimpleMoesifClient(String key, String url) {
+        this.moesifAPIClient = new MoesifAPIClient(key, url);
+        this.api = moesifAPIClient.getAPI();
+    }
+
     @Override
     public void publish(MetricEventBuilder builder) throws MetricReportingException {
         Map<String, Object> event = builder.build();

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.wso2.am.analytics.publisher.exception.MetricCreationException;
 import org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsMetricReporter;
 import org.wso2.am.analytics.publisher.reporter.elk.ELKMetricReporter;
+import org.wso2.am.analytics.publisher.reporter.moesif.MoesifReporter;
 import org.wso2.am.analytics.publisher.util.Constants;
 
 import java.lang.reflect.Constructor;
@@ -73,6 +74,21 @@ public class MetricReporterFactory {
         }
 
         MetricReporter reporterInstance = reporterRegistry.get(Constants.ELK_REPORTER);
+        log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
+                " is already created. Hence returning same instance");
+        return reporterInstance;
+    }
+
+    public MetricReporter createMoesifMetricReporter(Map<String, String> properties) throws MetricCreationException {
+        if (reporterRegistry.get(Constants.MOESIF_REPORTER) == null) {
+            synchronized (this) {
+                if (reporterRegistry.get(Constants.MOESIF_REPORTER) == null) {
+                    MetricReporter reporterInstance = new MoesifReporter(properties);
+                    reporterRegistry.put(Constants.MOESIF_REPORTER, reporterInstance);
+                }
+            }
+        }
+        MetricReporter reporterInstance = reporterRegistry.get(Constants.MOESIF_REPORTER);
         log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
                 " is already created. Hence returning same instance");
         return reporterInstance;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/MetricReporterFactory.java
@@ -80,15 +80,15 @@ public class MetricReporterFactory {
     }
 
     public MetricReporter createMoesifMetricReporter(Map<String, String> properties) throws MetricCreationException {
-        if (reporterRegistry.get(Constants.MOESIF_REPORTER) == null) {
+        if (reporterRegistry.get(Constants.MOESIF) == null) {
             synchronized (this) {
-                if (reporterRegistry.get(Constants.MOESIF_REPORTER) == null) {
+                if (reporterRegistry.get(Constants.MOESIF) == null) {
                     MetricReporter reporterInstance = new MoesifReporter(properties);
-                    reporterRegistry.put(Constants.MOESIF_REPORTER, reporterInstance);
+                    reporterRegistry.put(Constants.MOESIF, reporterInstance);
                 }
             }
         }
-        MetricReporter reporterInstance = reporterRegistry.get(Constants.MOESIF_REPORTER);
+        MetricReporter reporterInstance = reporterRegistry.get(Constants.MOESIF);
         log.info("Metric Reporter of type " + reporterInstance.getClass().toString().replaceAll("[\r\n]", "") +
                 " is already created. Hence returning same instance");
         return reporterInstance;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
@@ -46,6 +46,10 @@ public class EventQueue {
         this(queueSize, workerThreadCount, new SimpleMoesifClient(key));
     }
 
+    public EventQueue(int queueSize, int workerThreadCount, String key, String baseUrl) {
+        this(queueSize, workerThreadCount, new SimpleMoesifClient(key, baseUrl));
+    }
+
     public EventQueue(int queueSize, int workerThreadCount, MoesifKeyRetriever moesifKeyRetriever) {
         this(queueSize, workerThreadCount, new MoesifClient(moesifKeyRetriever));
     }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
@@ -31,11 +31,6 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.util.Map;
 import java.util.Timer;
 
-import static org.wso2.am.analytics.publisher.util.Constants.MOESIF;
-import static org.wso2.am.analytics.publisher.util.Constants.MOESIF_BASE_URL;
-import static org.wso2.am.analytics.publisher.util.Constants.MOESIF_KEY;
-import static org.wso2.am.analytics.publisher.util.Constants.TYPE;
-
 /**
  * Moesif Metric Reporter Implementation. This implementation is responsible for sending analytics data into Moesif
  * dashboard in a secure and reliable way.
@@ -54,8 +49,8 @@ public class MoesifReporter extends AbstractMetricReporter {
         if (properties.get(Constants.WORKER_THREAD_COUNT) != null) {
             workerThreads = Integer.parseInt(properties.get(Constants.WORKER_THREAD_COUNT));
         }
-        if (properties.get(TYPE).equals(MOESIF)) {
-            String moesifKey = properties.get(MOESIF_KEY);
+        if (properties.get(Constants.TYPE).equals(Constants.MOESIF)) {
+            String moesifKey = properties.get(Constants.MOESIF_KEY);
             String moesifBasePath = properties.get(Constants.MOESIF_BASE_URL);
             if (moesifBasePath == null || moesifBasePath.isEmpty()) {
                 this.eventQueue = new EventQueue(queueSize, workerThreads, moesifKey);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
@@ -31,8 +31,10 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.util.Map;
 import java.util.Timer;
 
+import static org.wso2.am.analytics.publisher.util.Constants.MOESIF;
 import static org.wso2.am.analytics.publisher.util.Constants.MOESIF_BASE_URL;
 import static org.wso2.am.analytics.publisher.util.Constants.MOESIF_KEY;
+import static org.wso2.am.analytics.publisher.util.Constants.TYPE;
 
 /**
  * Moesif Metric Reporter Implementation. This implementation is responsible for sending analytics data into Moesif
@@ -52,9 +54,9 @@ public class MoesifReporter extends AbstractMetricReporter {
         if (properties.get(Constants.WORKER_THREAD_COUNT) != null) {
             workerThreads = Integer.parseInt(properties.get(Constants.WORKER_THREAD_COUNT));
         }
-        if (properties.get("type").equals("moesif")) {
+        if (properties.get(TYPE).equals(MOESIF)) {
             String moesifKey = properties.get(MOESIF_KEY);
-            String moesifBasePath = properties.get(MOESIF_BASE_URL);
+            String moesifBasePath = properties.get(Constants.MOESIF_BASE_URL);
             if (moesifBasePath == null || moesifBasePath.isEmpty()) {
                 this.eventQueue = new EventQueue(queueSize, workerThreads, moesifKey);
             } else {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
@@ -31,6 +31,9 @@ import org.wso2.am.analytics.publisher.util.Constants;
 import java.util.Map;
 import java.util.Timer;
 
+import static org.wso2.am.analytics.publisher.util.Constants.MOESIF_BASE_URL;
+import static org.wso2.am.analytics.publisher.util.Constants.MOESIF_KEY;
+
 /**
  * Moesif Metric Reporter Implementation. This implementation is responsible for sending analytics data into Moesif
  * dashboard in a secure and reliable way.
@@ -49,9 +52,14 @@ public class MoesifReporter extends AbstractMetricReporter {
         if (properties.get(Constants.WORKER_THREAD_COUNT) != null) {
             workerThreads = Integer.parseInt(properties.get(Constants.WORKER_THREAD_COUNT));
         }
-        if (properties.get(Constants.TYPE).equals(Constants.MOESIF)) {
-            String moesifKey = properties.get(Constants.MOESIF_KEY);
-            this.eventQueue = new EventQueue(queueSize, workerThreads, moesifKey);
+        if (properties.get("type").equals("moesif")) {
+            String moesifKey = properties.get(MOESIF_KEY);
+            String moesifBasePath = properties.get(MOESIF_BASE_URL);
+            if (moesifBasePath == null || moesifBasePath.isEmpty()) {
+                this.eventQueue = new EventQueue(queueSize, workerThreads, moesifKey);
+            } else {
+                this.eventQueue = new EventQueue(queueSize, workerThreads, moesifKey, moesifBasePath);
+            }
         } else {
             String moesifBasePath = properties.get(
                     MoesifMicroserviceConstants.MOESIF_PROTOCOL_WITH_FQDN_KEY) + properties.get(

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -96,7 +96,6 @@ public class Constants {
     //Reporter constants
     public static final String DEFAULT_REPORTER = "default";
     public static final String ELK_REPORTER = "elk";
-    public static final String MOESIF_REPORTER = "moesif";
 
     //EventHub Client retry options constants
     public static final int DEFAULT_MAX_RETRIES = 2;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -135,8 +135,11 @@ public class Constants {
     public static final String NO_CACHE_VALUE = "no-cache";
     public static final String EXPIRES_VALUE = "-1";
     public static final String APPLICATION_JSON_UTF8_VALUE = "application/json; charset=utf-8";
+
     public static final String TYPE = "type";
     public static final String MOESIF = "moesif";
     public static final String MOESIF_KEY = "moesifKey";
-
+    public static final String MOESIF_BASE_URL = "moesif_base_url";
+    public static final String REQUEST_HEADERS = "requestHeaders";
+    public static final String RESPONSE_HEADERS = "responseHeaders";
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -141,4 +141,5 @@ public class Constants {
     public static final String MOESIF_BASE_URL = "moesif_base_url";
     public static final String REQUEST_HEADERS = "requestHeaders";
     public static final String RESPONSE_HEADERS = "responseHeaders";
+
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -138,7 +138,7 @@ public class Constants {
     public static final String TYPE = "type";
     public static final String MOESIF = "moesif";
     public static final String MOESIF_KEY = "moesifKey";
-    public static final String MOESIF_BASE_URL = "moesif_base_url";
+    public static String MOESIF_BASE_URL = "moesif_base_url";
     public static final String REQUEST_HEADERS = "requestHeaders";
     public static final String RESPONSE_HEADERS = "responseHeaders";
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -138,7 +138,7 @@ public class Constants {
     public static final String TYPE = "type";
     public static final String MOESIF = "moesif";
     public static final String MOESIF_KEY = "moesifKey";
-    public static String MOESIF_BASE_URL = "moesif_base_url";
+    public static final String MOESIF_BASE_URL = "moesif_base_url";
     public static final String REQUEST_HEADERS = "requestHeaders";
     public static final String RESPONSE_HEADERS = "responseHeaders";
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -96,6 +96,7 @@ public class Constants {
     //Reporter constants
     public static final String DEFAULT_REPORTER = "default";
     public static final String ELK_REPORTER = "elk";
+    public static final String MOESIF_REPORTER = "moesif";
 
     //EventHub Client retry options constants
     public static final int DEFAULT_MAX_RETRIES = 2;

--- a/features/publisher-client/pom.xml
+++ b/features/publisher-client/pom.xml
@@ -139,10 +139,6 @@
                                     <version>${proton-j.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>org.apache.qpid.proton-j</symbolicName>
-                                    <version>${proton-j.version}</version>
-                                </bundle>
-                                <bundle>
                                     <symbolicName>ua-parser</symbolicName>
                                     <version>${ua_parser.version}</version>
                                 </bundle>


### PR DESCRIPTION
This pull request introduces enhancements and new features to the Moesif metric reporting integration, focusing on configurability and header handling. The main improvements include support for custom request/response headers, the ability to specify a custom Moesif base URL, and updates to the factory and reporter classes to support these features.

**Moesif Integration Improvements**

* Added support for custom request and response headers in Moesif event publishing by checking for `REQUEST_HEADERS` and `RESPONSE_HEADERS` in the data map and merging them into the respective header maps in `AbstractMoesifClient.java`. [[1]](diffhunk://#diff-aa2fa340a221f66a5b934afdbc0b2fe1234329284a0434ba8d8234ca74b1aac4R54-R68) [[2]](diffhunk://#diff-37a8eb7f0ad67879d673ccd399e801a6b2eec72e623157e5199302163e781bdbR137-R143)
* Introduced optional configuration for a custom Moesif base URL, allowing instantiation of `SimpleMoesifClient` and `EventQueue` with a specific endpoint if provided in properties. [[1]](diffhunk://#diff-48560073cd72e7802031d05ff08a150eeeae332178d6e49436ee7a9e6969fef9R62-R66) [[2]](diffhunk://#diff-359c09def7691058f1b3096d57dedfcd3e74ee92954a243e2c0af6fb2aed04f6R49-R52) [[3]](diffhunk://#diff-f27cebbb724ca42ad4e473de9df6aadd72593bb5ea1a3085143b0ad0e952bf18L52-R64) [[4]](diffhunk://#diff-37a8eb7f0ad67879d673ccd399e801a6b2eec72e623157e5199302163e781bdbR137-R143)

**Factory and Reporter Enhancements**

* Added `createMoesifMetricReporter` method to `MetricReporterFactory` for singleton instantiation and retrieval of `MoesifReporter` based on provided properties. [[1]](diffhunk://#diff-ae2c280f58b2055a864958b89f99c005fe60ba54c293add6a5963496ee896b41R82-R96) [[2]](diffhunk://#diff-ae2c280f58b2055a864958b89f99c005fe60ba54c293add6a5963496ee896b41R26)
* Updated `MoesifReporter` to use new constants and support the custom base URL and header features, improving flexibility and reliability. [[1]](diffhunk://#diff-f27cebbb724ca42ad4e473de9df6aadd72593bb5ea1a3085143b0ad0e952bf18L52-R64) [[2]](diffhunk://#diff-f27cebbb724ca42ad4e473de9df6aadd72593bb5ea1a3085143b0ad0e952bf18R34-R38) [[3]](diffhunk://#diff-37a8eb7f0ad67879d673ccd399e801a6b2eec72e623157e5199302163e781bdbR137-R143)

**Miscellaneous**

* Removed duplicate bundle entry for `org.apache.qpid.proton-j` in `features/publisher-client/pom.xml` for cleaner dependency management.