### PR TITLE
Add API_RESOURCE_TEMPLATE

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -185,7 +185,7 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
                 Constants.CORRELATION_ID, Constants.RESPONSE_CACHE_HIT, Constants.USER_NAME,
                 Constants.RESPONSE_MEDIATION_LATENCY, Constants.DESTINATION, Constants.ERROR_CODE,
                 Constants.ERROR_MESSAGE, Constants.ERROR_TYPE, Constants.TARGET_RESPONSE_CODE,
-                Constants.REQUEST_MEDIATION_LATENCY
+                Constants.REQUEST_MEDIATION_LATENCY, Constants.API_RESOURCE_TEMPLATE
         ));
 
         data.entrySet().stream().filter(entry -> requiredKeys.contains(entry.getKey()))


### PR DESCRIPTION
This pull request makes a minor update to the metadata population logic in the `SimpleMoesifClient` class. It adds a new required key to ensure that the API resource template is included in the metadata.

* Added `Constants.API_RESOURCE_TEMPLATE` to the list of required keys in the `populateMetadata` method within `SimpleMoesifClient.java`, ensuring this metadata field is captured and sent.