### PR TITLE
Add MCP analytics support

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -342,6 +342,9 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
         if (data.get(Constants.PROPERTIES) != null) {
             Map<String, Object> properties = (Map<String, Object>) data.get(Constants.PROPERTIES);
             if (properties.containsKey(Constants.MCP_ANALYTICS)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("MCP analytics data found and transferred to metadata");
+                }
                 metadata.put(Constants.MCP_ANALYTICS, properties.remove(Constants.MCP_ANALYTICS));
             }
         }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -195,6 +195,8 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
 
         // Add AI metadata and token usage if present
         populateAIInfo(data, metadata);
+        // Add MCP metadata if present
+        populateMCPInfo(data, metadata);
 
     }
 
@@ -323,6 +325,25 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
                 metadata.put(Constants.SUBTYPE, properties.remove(Constants.SUBTYPE));
             }
             metadata.putAll(properties);
+        }
+    }
+
+    /**
+     * Populates MCP analytics information into the metadata map if available in the source data.
+     *
+     * This method checks for the presence of MCP analytics data in the properties of the source
+     * data map. If found, it removes the analytics data from the source map and transfers it
+     * to the metadata map.
+     *
+     * @param data     The source data map containing various fields, including properties with MCP analytics information.
+     * @param metadata The target metadata map that will be populated with MCP analytics data if present in the source data.
+     */
+    private void populateMCPInfo(Map<String, Object> data, Map<String, Object> metadata) {
+        if (data.get(Constants.PROPERTIES) != null) {
+            Map<String, Object> properties = (Map<String, Object>) data.get(Constants.PROPERTIES);
+            if (properties.containsKey(Constants.MCP_ANALYTICS)) {
+                metadata.put(Constants.MCP_ANALYTICS, properties.remove(Constants.MCP_ANALYTICS));
+            }
         }
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -71,6 +71,7 @@ public class Constants {
     public static final String AI_COMPLETION_TOKEN_USAGE = "completionTokens";
     public static final String AI_TOTAL_TOKEN_USAGE = "totalTokens";
     public static final String NOT_APPLICABLE = "N/A";
+    public static final String MCP_ANALYTICS = "mcpAnalytics";
 
     //Builder event types
     public static final String RESPONSE_EVENT_TYPE = "response";


### PR DESCRIPTION
This pull request enhances the analytics publisher client by adding support for handling MCP (Multi-Channel Processing) analytics metadata. The main changes involve extracting MCP analytics information from the input data and including it in the metadata sent to the analytics backend.

**Support for MCP analytics metadata:**

* Added a new constant `MCP_ANALYTICS` in `Constants.java` to represent the MCP analytics field.
* Introduced a new method `populateMCPInfo` in `SimpleMoesifClient.java` that checks for MCP analytics data in the properties map, removes it from the source, and adds it to the metadata map.
* Updated the `populateMetadata` method in `SimpleMoesifClient.java` to call `populateMCPInfo`, ensuring MCP analytics data is handled similarly to AI metadata.

Related PRs: https://github.com/wso2/carbon-apimgt/pull/13540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Multi-Cloud Platform (MCP) analytics: MCP analytics data is now extracted from incoming payloads and moved into the analytics metadata bundle.
  * Implementation is internal only; there are no public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->