### PR TITLE
Add env specific grouping for moesif

### DIFF
--- a/component/publisher-client/pom.xml
+++ b/component/publisher-client/pom.xml
@@ -136,6 +136,7 @@
                             org.wso2.am.analytics.publisher.exception.*;version="${project.version}",
                             org.wso2.am.analytics.publisher.auth.*;version="${project.version}",
                             org.wso2.am.analytics.publisher.util.*;version="${project.version}",
+                            org.wso2.am.analytics.publisher.properties.*;version="${project.version}",
                         </Export-Package>
                         <Private-Package>
                         </Private-Package>

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -100,6 +100,7 @@ public class MoesifClient {
      */
     public void publish(MetricEventBuilder builder) throws MetricReportingException {
         Map<String, Object> event = builder.build();
+        log.info("Publishing metric event for Moesif analytics.");
         log.debug("Event data structure: {}", event.keySet());
         String orgId = (String) event.get(Constants.ORGANIZATION_ID);
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -31,6 +31,7 @@ import com.moesif.api.models.EventResponseModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.properties.OrgMoesifKeyMapping;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifMicroserviceConstants;
 import org.wso2.am.analytics.publisher.retriever.MoesifKeyRetriever;
@@ -45,7 +46,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Moesif Client is responsible for sending events to
@@ -80,35 +80,69 @@ public class MoesifClient {
     }
 
     /**
-     * publish method is responsible for checking the availability of relevant moesif key
+          * Gets the OrgMoesifKeyMapping for a specific organization.
+     *
+     * @param orgId The organization FID.
+     * @return OrgMoesifKeyMapping instance, or null if not found.
+     */
+    private OrgMoesifKeyMapping getOrgMoesifKeyMapping(String orgId) {
+        Map<String, Map<String, String>> orgIDMoesifKeyMap = keyRetriever.getMoesifKeyMap();
+        if (orgIDMoesifKeyMap.containsKey(orgId)) {
+            return new OrgMoesifKeyMapping(orgId, orgIDMoesifKeyMap.get(orgId));
+        }
+        return null;
+    }
+
+    /**
+     * publish method is responsible for checking the availability of relevant
+     * moesif key
      * and initiating moesif client sdk.
      */
     public void publish(MetricEventBuilder builder) throws MetricReportingException {
         Map<String, Object> event = builder.build();
-        ConcurrentHashMap<String, String> orgIDMoesifKeyMap = keyRetriever.getMoesifKeyMap();
-        ConcurrentHashMap<String, String> orgIdEnvMap = keyRetriever.getEnvMap();
-        LinkedHashMap properties = (LinkedHashMap) event.get(Constants.PROPERTIES);
-
+        log.debug("Event data structure: {}", event.keySet());
         String orgId = (String) event.get(Constants.ORGANIZATION_ID);
-        String moesifKey;
+
+        if (orgId == null || orgId.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Event missing organization ID. Skipping event.");
+            } 
+        }
+
+        Map properties = (LinkedHashMap) event.get(Constants.PROPERTIES);
+        
+        if (properties == null) {
+            log.debug("Event missing properties. Skipping event for organization: {}", orgId);
+            return;
+        }
+        
         String eventEnvironment = (String) properties.get(Constants.DEPLOYMENT_TYPE);
-        String userSelectedEnvironment;
-        if (orgIDMoesifKeyMap.containsKey(orgId)) {
-            moesifKey = orgIDMoesifKeyMap.get(orgId);
-            if (orgIdEnvMap.containsKey(orgId)) {
-                userSelectedEnvironment = orgIdEnvMap.get(orgId);
-            } else {
+        if (eventEnvironment == null || eventEnvironment.isEmpty()) {
+            log.debug("Event missing environment for organization: {}. Skipping event.", orgId);
+            return;
+        }
+        
+        OrgMoesifKeyMapping orgKeyMapping = getOrgMoesifKeyMapping(orgId);
+        if (orgKeyMapping == null) {
+            log.debug("No Moesif key found for organization: {}. Skipping event.", orgId);
+            return;
+        }
+
+        String moesifKey;
+
+        // If old records with only one environment, use that single key
+        if (orgKeyMapping.hasSingleEnvironment()) {
+            moesifKey = orgKeyMapping.getSingleEnvironmentKey();
+        } else {
+            // Multiple environments exist, get key for specific environment
+            moesifKey = orgKeyMapping.getMoesifKeyForEnvironment(eventEnvironment);
+            if (moesifKey == null) {
+                log.debug("No Moesif key found for organization: {} and environment: {}. Skipping event.",
+                        orgId, eventEnvironment);
                 return;
             }
-        } else {
-            return;
         }
 
-        if (Constants.PRODUCTION.equals(userSelectedEnvironment) && !Constants.PRODUCTION.equals(eventEnvironment)) {
-            return;
-        }
-
-        // init moesif api client
         MoesifAPIClient client = new MoesifAPIClient(moesifKey);
 
         // api object is a singleton which will make calls to

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/OrgMoesifKeyMapping.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/properties/OrgMoesifKeyMapping.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.analytics.publisher.properties;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Represents the Moesif key mapping for an organization.
+ * Maps environment names to their corresponding Moesif API keys.
+ * Also supports grouping events by environment for batch processing.
+ * Thread-safe for concurrent access.
+ */
+public class OrgMoesifKeyMapping {
+    private volatile String organizationId;
+    private final Map<String, String> environmentKeyMap;
+
+    /**
+     * Default constructor.
+     */
+    public OrgMoesifKeyMapping() {
+        this.environmentKeyMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Constructor with organization ID.
+     *
+     * @param organizationId The organization ID.
+     */
+    public OrgMoesifKeyMapping(String organizationId) {
+        this.organizationId = organizationId;
+        this.environmentKeyMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Constructor with organization ID and environment key map.
+     *
+     * @param organizationId      The organization ID.
+     * @param environmentKeyMap   Map of environment to Moesif key.
+     */
+    public OrgMoesifKeyMapping(String organizationId, Map<String, String> environmentKeyMap) {
+        this.organizationId = organizationId;
+        this.environmentKeyMap = new ConcurrentHashMap<>();
+        if (environmentKeyMap != null) {
+            for (Map.Entry<String, String> entry : environmentKeyMap.entrySet()) {
+                String key = entry.getKey();
+                if (key != null) {
+                    this.environmentKeyMap.put(key.toLowerCase(), entry.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the organization ID.
+     *
+     * @return The organization ID.
+     */
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    /**
+     * Gets the environment to Moesif key mapping.
+     *
+     * @return Map of environment names to Moesif API keys.
+     */
+    public Map<String, String> getEnvironmentKeyMap() {
+        return Collections.unmodifiableMap(environmentKeyMap);
+    }
+
+        /**
+     * Gets the Moesif key for a specific environment.
+     * Environment name comparison is case-insensitive.
+     *
+     * @param environment The environment name.
+     * @return The Moesif API key for the environment, or null if not found.
+     */
+    public String getMoesifKeyForEnvironment(String environment) {
+        if (environment == null) {
+            return null;
+        }
+        return environmentKeyMap.get(environment.toLowerCase());
+    }
+
+    /**
+     * Checks if the organization has a Moesif key configured.
+     *
+     * @return true if at least one environment key is configured, false otherwise.
+     */
+    public boolean hasKeys() {
+        return !environmentKeyMap.isEmpty();
+    }
+
+    /**
+     * Checks if the organization has exactly one environment configured.
+     *
+     * @return true if only one environment key exists, false otherwise.
+     */
+    public boolean hasSingleEnvironment() {
+        return environmentKeyMap.size() == 1;
+    }
+
+    /**
+     * Gets the single Moesif key when only one environment exists.
+     *
+     * @return The Moesif API key if only one exists, null otherwise.
+     */
+    public String getSingleEnvironmentKey() {
+        if (hasSingleEnvironment()) {
+            for (String value : environmentKeyMap.values()) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MissedEventHandler.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MissedEventHandler.java
@@ -37,10 +37,9 @@ public class MissedEventHandler extends TimerTask {
 
     @Override
     public void run() {
+        log.info("Starting missed event handler refresh process");
         // clear the internal map of orgID-MoesifKey
         keyRetriever.clearMoesifKeyMap();
-        // clear the environment map
-        keyRetriever.clearEnvMap();
         // refresh the internal map of orgID-MoesifKey
         keyRetriever.initOrRefreshOrgIDMoesifKeyMap();
     }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
@@ -41,6 +41,7 @@ public class MoesifReporter extends AbstractMetricReporter {
 
     public MoesifReporter(Map<String, String> properties) throws MetricCreationException {
         super(properties);
+        log.info("Initializing Moesif Reporter with properties: {}", properties);
         String moesifBasePath = properties.get(MoesifMicroserviceConstants.MOESIF_PROTOCOL_WITH_FQDN_KEY) +
                 properties.get(MoesifMicroserviceConstants.MOESIF_MS_VERSIONING_KEY);
         MoesifKeyRetriever keyRetriever =

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/retriever/MoesifKeyRetriever.java
@@ -39,6 +39,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -51,8 +52,7 @@ import javax.net.ssl.HttpsURLConnection;
 public class MoesifKeyRetriever {
     private static final Logger log = LoggerFactory.getLogger(MoesifKeyRetriever.class);
     private static MoesifKeyRetriever moesifKeyRetriever;
-    private ConcurrentHashMap<String, String> orgIDMoesifKeyMap;
-    private ConcurrentHashMap<String, String> orgIdEnvMap;
+    private Map<String, Map<String, String>> orgIDMoesifKeyMap;
     // username of Moesif microservice
     private String msAuthUsername;
     // password of Moesif microservice
@@ -63,8 +63,7 @@ public class MoesifKeyRetriever {
 
         this.msAuthUsername = authUsername;
         this.msAuthPwd = authPwd.toCharArray();
-        orgIDMoesifKeyMap = new ConcurrentHashMap();
-        orgIdEnvMap = new ConcurrentHashMap();
+        orgIDMoesifKeyMap = new ConcurrentHashMap<>();
         this.moesifBasePath = moesifBasePath;
     }
 
@@ -276,8 +275,8 @@ public class MoesifKeyRetriever {
         String orgID = newKey.getOrganization_id();
         String moesifKey = newKey.getMoesif_key();
         String env = newKey.getEnv();
-        orgIDMoesifKeyMap.put(orgID, moesifKey);
-        orgIdEnvMap.put(orgID, env);
+        orgIDMoesifKeyMap.computeIfAbsent(orgID, k -> new ConcurrentHashMap<>()).put(env, moesifKey);
+        log.info("Updated Moesif key for organization: {} and environment: {}", orgID, env);
     }
 
     private synchronized void updateMap(String response) {
@@ -300,8 +299,13 @@ public class MoesifKeyRetriever {
             String orgID = entry.getOrganization_id();
             String env = entry.getEnv();
             String moesifKey = entry.getMoesif_key();
-            orgIDMoesifKeyMap.put(orgID, moesifKey);
-            orgIdEnvMap.put(orgID, env);
+            if (orgID == null || env == null || moesifKey == null) {
+                log.warn("Skipping entry with null values - orgID: {}, env: {}, key present: {}",
+                orgID, env, moesifKey != null);
+                continue;
+            }
+            orgIDMoesifKeyMap.computeIfAbsent(orgID, k -> new ConcurrentHashMap<>()).put(env, moesifKey);
+            log.info("Successfully updated Moesif keys for {} organizations", orgIDMoesifKeyMap.size());
         }
     }
 
@@ -310,23 +314,13 @@ public class MoesifKeyRetriever {
      *
      * @return orgIDMoesifKeyMap
      */
-    public ConcurrentHashMap<String, String> getMoesifKeyMap() {
+    public Map<String, Map<String, String>> getMoesifKeyMap() {
         return orgIDMoesifKeyMap;
-    }
-
-    public ConcurrentHashMap<String, String> getEnvMap() {
-        return orgIdEnvMap;
     }
 
     public void clearMoesifKeyMap() {
         if (!orgIDMoesifKeyMap.isEmpty()) {
             orgIDMoesifKeyMap.clear();
-        }
-    }
-
-    public void clearEnvMap() {
-        if (!orgIdEnvMap.isEmpty()) {
-            orgIdEnvMap.clear();
         }
     }
 


### PR DESCRIPTION
This pull request refactors the way Moesif API keys are managed and retrieved for different organizations and environments, improving support for multi-environment configurations. The changes include the introduction of a new `OrgMoesifKeyMapping` class, updates to the Moesif key retrieval logic, and several codebase cleanups and logging improvements.

**Key changes:**

### Multi-environment Moesif key management

* Introduced the `OrgMoesifKeyMapping` class to encapsulate the mapping of organization IDs to environment-specific Moesif API keys, supporting better handling of organizations with multiple deployment environments.
* Updated the `MoesifKeyRetriever` to store Moesif keys as a map of organization IDs to environment-key maps, replacing the previous flat map structure. Methods for retrieving and updating keys now work with this new structure. [[1]](diffhunk://#diff-25d9755b92a1d53a2d3f62f9c0c33071dabbea54d1357d847765f879bd707586L54-R55) [[2]](diffhunk://#diff-25d9755b92a1d53a2d3f62f9c0c33071dabbea54d1357d847765f879bd707586L279-R279) [[3]](diffhunk://#diff-25d9755b92a1d53a2d3f62f9c0c33071dabbea54d1357d847765f879bd707586L303-R308) [[4]](diffhunk://#diff-25d9755b92a1d53a2d3f62f9c0c33071dabbea54d1357d847765f879bd707586L313-L332)
* Refactored `MoesifClient` to use the new mapping structure, including logic to select the correct Moesif key based on the event's organization and environment, and improved validation and logging when publishing events. [[1]](diffhunk://#diff-a962daccef11781bd97c25fa6e416eb62535dc1709532935acaf78eb458fc96eR34) [[2]](diffhunk://#diff-a962daccef11781bd97c25fa6e416eb62535dc1709532935acaf78eb458fc96eL83-L111)

### Codebase cleanup and logging improvements

* Removed unused imports and obsolete environment map handling from `MoesifClient` and `MissedEventHandler`. [[1]](diffhunk://#diff-a962daccef11781bd97c25fa6e416eb62535dc1709532935acaf78eb458fc96eL48) [[2]](diffhunk://#diff-dab47ca10763d39cd9cf80b55d6e8ccaa828f283ede2109a57b1ddb6469c7010R40-L43)
* Added informative logging to key lifecycle events, such as initialization of the Moesif reporter and updates to Moesif keys. [[1]](diffhunk://#diff-f27cebbb724ca42ad4e473de9df6aadd72593bb5ea1a3085143b0ad0e952bf18R44) [[2]](diffhunk://#diff-25d9755b92a1d53a2d3f62f9c0c33071dabbea54d1357d847765f879bd707586L279-R279) [[3]](diffhunk://#diff-25d9755b92a1d53a2d3f62f9c0c33071dabbea54d1357d847765f879bd707586L303-R308) [[4]](diffhunk://#diff-dab47ca10763d39cd9cf80b55d6e8ccaa828f283ede2109a57b1ddb6469c7010R40-L43)

### Packaging and dependency updates

* Updated the `pom.xml` to export the new `org.wso2.am.analytics.publisher.properties` package, making the new mapping class available to consumers.## Purpose
