### PR TITLE
Add moesif event base url as a configurable

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -54,9 +54,10 @@ import java.util.Map;
 public class MoesifClient {
     private final Logger log = LoggerFactory.getLogger(MoesifClient.class);
     private final MoesifKeyRetriever keyRetriever;
-
-    public MoesifClient(MoesifKeyRetriever keyRetriever) {
+    String baseEventUrl;
+    public MoesifClient(MoesifKeyRetriever keyRetriever, String baseEventUrl) {
         this.keyRetriever = keyRetriever;
+        this.baseEventUrl = baseEventUrl;
     }
 
     private void doRetry(String orgId, MetricEventBuilder builder) {
@@ -144,7 +145,8 @@ public class MoesifClient {
             }
         }
 
-        MoesifAPIClient client = new MoesifAPIClient(moesifKey);
+
+        MoesifAPIClient client = new MoesifAPIClient(moesifKey, baseEventUrl);
 
         // api object is a singleton which will make calls to
         // moesif endpoints with the latest MoesifAPI client being provided.

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -54,7 +54,7 @@ import java.util.Map;
 public class MoesifClient {
     private final Logger log = LoggerFactory.getLogger(MoesifClient.class);
     private final MoesifKeyRetriever keyRetriever;
-    String baseEventUrl;
+    private final String baseEventUrl;
     public MoesifClient(MoesifKeyRetriever keyRetriever, String baseEventUrl) {
         this.keyRetriever = keyRetriever;
         this.baseEventUrl = baseEventUrl;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -28,6 +28,7 @@ import com.moesif.api.models.EventRequestModel;
 import com.moesif.api.models.EventResponseBuilder;
 import com.moesif.api.models.EventResponseModel;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
@@ -146,8 +147,12 @@ public class MoesifClient {
         }
 
 
-        MoesifAPIClient client = new MoesifAPIClient(moesifKey, baseEventUrl);
-
+        MoesifAPIClient client;
+        if(!StringUtils.isBlank(baseEventUrl)) {
+            client = new MoesifAPIClient(moesifKey, baseEventUrl);
+        } else {
+            client = new MoesifAPIClient(moesifKey);
+        }
         // api object is a singleton which will make calls to
         // moesif endpoints with the latest MoesifAPI client being provided.
         // Hence avoid maintaining a map of MoesifAPIClient against moesif keys.

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/EventQueue.java
@@ -40,10 +40,11 @@ public class EventQueue {
     private final ExecutorService publisherExecutorService;
     private final AtomicInteger failureCount;
 
-    public EventQueue(int queueSize, int workerThreadCount, MoesifKeyRetriever moesifKeyRetriever) {
+    public EventQueue(int queueSize, int workerThreadCount, MoesifKeyRetriever moesifKeyRetriever, 
+        String baseEventUrl) {
         publisherExecutorService = Executors.newFixedThreadPool(workerThreadCount,
                 new DefaultAnalyticsThreadFactory("Queue-Worker"));
-        MoesifClient moesifClient = new MoesifClient(moesifKeyRetriever);
+        MoesifClient moesifClient = new MoesifClient(moesifKeyRetriever, baseEventUrl);
         eventQueue = new LinkedBlockingQueue<>(queueSize);
         failureCount = new AtomicInteger(0);
         for (int i = 0; i < workerThreadCount; i++) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/MoesifReporter.java
@@ -56,7 +56,8 @@ public class MoesifReporter extends AbstractMetricReporter {
         if (properties.get(Constants.WORKER_THREAD_COUNT) != null) {
             workerThreads = Integer.parseInt(properties.get(Constants.WORKER_THREAD_COUNT));
         }
-        this.eventQueue = new EventQueue(queueSize, workerThreads, keyRetriever);
+        String baseEventUrl = properties.get(MoesifMicroserviceConstants.MOESIF_EVENT_PUBLISHER_URL);
+        this.eventQueue = new EventQueue(queueSize, workerThreads, keyRetriever, baseEventUrl);
 
         MissedEventHandler missedEventHandler = new MissedEventHandler(keyRetriever);
         // execute MissedEventHandler periodically.

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifMicroserviceConstants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/moesif/util/MoesifMicroserviceConstants.java
@@ -22,6 +22,7 @@ package org.wso2.am.analytics.publisher.reporter.moesif.util;
  */
 public class MoesifMicroserviceConstants {
     public static final String MOESIF_PROTOCOL_WITH_FQDN_KEY = "moesifProtocolWithFQDN";
+    public static final String MOESIF_EVENT_PUBLISHER_URL = "moesifEventPublisherURL";
     public static final String MOESIF_EP_COMMON_PATH = "moesif/moesif_key";
     public static final String MOESIF_MS_VERSIONING_KEY = "moesifMSVersioning";
     public static final String MS_USERNAME_CONFIG_KEY = "moesifMSAuthUsername";

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/ErrorHandlingTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/ErrorHandlingTestCase.java
@@ -69,6 +69,9 @@ public class ErrorHandlingTestCase {
         UnitTestAppender appender = config.getAppender("UnitTestAppender");
         log.atLevel(Level.DEBUG);
 
+        // Clear messages from previous test
+        appender.getMessages().clear();
+
         Map<String, String> configMap = new HashMap<>();
         configMap.put(Constants.AUTH_API_URL, "https://localhost:1234/non-existance");
         configMap.put(Constants.AUTH_API_TOKEN, "some_token");
@@ -76,8 +79,8 @@ public class ErrorHandlingTestCase {
         factory.reset();
         MetricReporter metricReporter = factory.createMetricReporter(configMap);
         CounterMetric metric = metricReporter.createCounterMetric("test-connection-counter", MetricSchema.RESPONSE);
+        Thread.sleep(3000);
         List<String> messages = appender.getMessages();
-        Thread.sleep(1000);
         Assert.assertTrue(TestUtils.isContains(messages, "Recoverable error occurred when creating Eventhub Client. "
                                                          + "Retry attempts will be made"));
         Assert.assertTrue(TestUtils.isContains(messages, "Provided authentication endpoint "

--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MoesifMetricBuilderTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/MoesifMetricBuilderTestCase.java
@@ -45,7 +45,7 @@ public class MoesifMetricBuilderTestCase {
     public void createBuilder() throws MetricCreationException {
         MoesifKeyRetriever keyRetriever =
                 MoesifKeyRetriever.getInstance("some_username", "some_password", "dummyMoesifBasePath");
-        EventQueue queue = new EventQueue(100, 1, keyRetriever);
+        EventQueue queue = new EventQueue(100, 1, keyRetriever, "https://api-dev.moesif.net");
         MoesifCounterMetric metric =
                 new MoesifCounterMetric("test.builder.metric", queue, MetricSchema.CHOREO_RESPONSE);
         builder = metric.getEventBuilder();


### PR DESCRIPTION
This pull request introduces support for configuring the Moesif event publisher URL, enabling greater flexibility in specifying the endpoint for event publishing. The changes propagate the new `baseEventUrl` configuration through constructors and properties, update related constants, and adjust tests accordingly.

**Configuration and Constructor Updates:**

* Added a new constant `MOESIF_EVENT_PUBLISHER_URL` in `MoesifMicroserviceConstants` to represent the event publisher URL key.
* Updated constructors in `MoesifClient` and `EventQueue` to accept and store the `baseEventUrl` parameter, ensuring it is available when initializing the Moesif API client. [[1]](diffhunk://#diff-a962daccef11781bd97c25fa6e416eb62535dc1709532935acaf78eb458fc96eL57-R60) [[2]](diffhunk://#diff-359c09def7691058f1b3096d57dedfcd3e74ee92954a243e2c0af6fb2aed04f6L43-R47)
* Modified `MoesifReporter` to read the `baseEventUrl` from properties and pass it to `EventQueue`.

**Event Publishing Logic:**

* Updated the instantiation of `MoesifAPIClient` in `MoesifClient` to use the new `baseEventUrl` parameter, ensuring events are sent to the configured endpoint.

**Test Adjustments:**

* Updated test cases to accommodate the new constructor signature for `EventQueue`, providing a `baseEventUrl` as needed.
* Improved log message handling in `ErrorHandlingTestCase` by clearing previous messages and adjusting sleep timing for more reliable assertions.## Purpose