### PR TITLE
Add analytics support for MCP

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -322,6 +322,12 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             if (properties.containsKey(Constants.SUBTYPE)) {
                 metadata.put(Constants.SUBTYPE, properties.remove(Constants.SUBTYPE));
             }
+            if (properties.containsKey(Constants.IS_GUARDRAIL_HIT)) {
+                metadata.put(Constants.IS_GUARDRAIL_HIT, properties.remove(Constants.IS_GUARDRAIL_HIT));
+            }
+            if (properties.containsKey(Constants.GUARDRAIL_NAME)) {
+                metadata.put(Constants.GUARDRAIL_NAME, properties.remove(Constants.GUARDRAIL_NAME));
+            }
             if (properties.containsKey(Constants.MCP_ANALYTICS)) {
                 if (log.isDebugEnabled()) {
                     log.debug("MCP analytics data found and transferred to metadata");

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -342,6 +342,9 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
         if (data.get(Constants.PROPERTIES) != null) {
             Map<String, Object> properties = (Map<String, Object>) data.get(Constants.PROPERTIES);
             if (properties.containsKey(Constants.MCP_ANALYTICS)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("MCP analytics data found and transferred to metadata");
+                }
                 metadata.put(Constants.MCP_ANALYTICS, properties.remove(Constants.MCP_ANALYTICS));
             }
         }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -195,6 +195,8 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
 
         // Add AI metadata and token usage if present
         populateAIInfo(data, metadata);
+        // Add MCP metadata if present
+        populateMCPInfo(data, metadata);
 
     }
 
@@ -323,6 +325,25 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
                 metadata.put(Constants.SUBTYPE, properties.remove(Constants.SUBTYPE));
             }
             metadata.putAll(properties);
+        }
+    }
+
+    /**
+     * Populates MCP analytics information into the metadata map if available in the source data.
+     *
+     * This method checks for the presence of MCP analytics data in the properties of the source
+     * data map. If found, it removes the analytics data from the source map and transfers it
+     * to the metadata map.
+     *
+     * @param data     The source data map containing various fields, including properties with MCP analytics information.
+     * @param metadata The target metadata map that will be populated with MCP analytics data if present in the source data.
+     */
+    private void populateMCPInfo(Map<String, Object> data, Map<String, Object> metadata) {
+        if (data.get(Constants.PROPERTIES) != null) {
+            Map<String, Object> properties = (Map<String, Object>) data.get(Constants.PROPERTIES);
+            if (properties.containsKey(Constants.MCP_ANALYTICS)) {
+                metadata.put(Constants.MCP_ANALYTICS, properties.remove(Constants.MCP_ANALYTICS));
+            }
         }
     }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -193,10 +193,8 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
                 .filter(entry -> entry.getValue() != null)
                 .forEach(entry -> metadata.put(entry.getKey(), entry.getValue()));
 
-        // Add AI metadata and token usage if present
+        // Add AI metadata, token usage and MCP info if present
         populateAIInfo(data, metadata);
-        // Add MCP metadata if present
-        populateMCPInfo(data, metadata);
 
     }
 
@@ -324,29 +322,14 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             if (properties.containsKey(Constants.SUBTYPE)) {
                 metadata.put(Constants.SUBTYPE, properties.remove(Constants.SUBTYPE));
             }
-            metadata.putAll(properties);
-        }
-    }
-
-    /**
-     * Populates MCP analytics information into the metadata map if available in the source data.
-     *
-     * This method checks for the presence of MCP analytics data in the properties of the source
-     * data map. If found, it removes the analytics data from the source map and transfers it
-     * to the metadata map.
-     *
-     * @param data     The source data map containing various fields, including properties with MCP analytics information.
-     * @param metadata The target metadata map that will be populated with MCP analytics data if present in the source data.
-     */
-    private void populateMCPInfo(Map<String, Object> data, Map<String, Object> metadata) {
-        if (data.get(Constants.PROPERTIES) != null) {
-            Map<String, Object> properties = (Map<String, Object>) data.get(Constants.PROPERTIES);
             if (properties.containsKey(Constants.MCP_ANALYTICS)) {
                 if (log.isDebugEnabled()) {
                     log.debug("MCP analytics data found and transferred to metadata");
                 }
                 metadata.put(Constants.MCP_ANALYTICS, properties.remove(Constants.MCP_ANALYTICS));
             }
+            metadata.putAll(properties);
         }
     }
+
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -64,6 +64,8 @@ public class Constants {
     public static final String AI_TOKEN_USAGE = "aiTokenUsage";
     public static final String IS_EGRESS = "isEgress";
     public static final String SUBTYPE = "subtype";
+    public static final String IS_GUARDRAIL_HIT = "isGuardrailHit";
+    public static final String GUARDRAIL_NAME = "guardrailName";
     public static final String AI_VENDOR_NAME = "vendorName";
     public static final String AI_VENDOR_VERSION = "vendorVersion";
     public static final String AI_MODEL = "model";

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -71,6 +71,7 @@ public class Constants {
     public static final String AI_COMPLETION_TOKEN_USAGE = "completionTokens";
     public static final String AI_TOTAL_TOKEN_USAGE = "totalTokens";
     public static final String NOT_APPLICABLE = "N/A";
+    public static final String MCP_ANALYTICS = "mcpAnalytics";
 
     //Builder event types
     public static final String RESPONSE_EVENT_TYPE = "response";


### PR DESCRIPTION
## Purpose
$subject


## Approach

A new MCP_ANALYTICS constant is introduced to track metadata, and its handling is integrated into the SimpleMoesifClient's AI metadata population and aggregation logic to ensure the metadata is properly transferred and included when present.

## Related Issues

- https://github.com/wso2/api-manager/issues/4688

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/13612
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics metadata handling to include guardrail indicators, guardrail name, and MCP analytics, propagating these attributes into published metadata and emitting optional debug logs when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->