### PR TITLE
 Improve event rejection test after unrecoverable exception

### DIFF
--- a/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/EventHubClientTestCase.java
+++ b/component/publisher-client/src/test/java/org/wso2/am/analytics/publisher/EventHubClientTestCase.java
@@ -60,6 +60,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -207,10 +208,16 @@ public class EventHubClientTestCase extends AuthAPIMockService {
         List<String> messages = new ArrayList<String>(appender.getMessages());
         Assert.assertTrue(TestUtils.isContains(messages, msg));
 
+        // Reset the mock to create fresh builder for second event
+        MetricEventBuilder secondBuilder = metric.getEventBuilder();
+        TestUtils.populateBuilder(secondBuilder);
+
         // try to publish another event
-        metric.incrementCount(builder);
+        metric.incrementCount(secondBuilder);
         // waiting to confirm that the event is not added to the queue
-        verify(eventDataBatch, timeout(10000).times(1)).tryAdd(any(EventData.class));
+        Thread.sleep(2000);
+        // verify it is not trying to add event queue, after identified unrecoverable error
+        verify(eventDataBatch, times(1)).tryAdd(any(EventData.class));
     }
 
 


### PR DESCRIPTION
## Description 

$subject

- Create new MetricEventBuilder instance for second event attempt
- Verify system correctly rejects events after ConnectionUnrecoverableException
- Add explicit Thread.sleep to ensure async operations complete
- Ensure only first event is queued (verify times(1) unchanged)
- Improve test reliability by using fresh builder instead of reusing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved event-publishing tests to verify correct behavior when a connection becomes unrecoverable, including handling of a subsequent event.
  * Strengthened verification that failed events are not re-queued after recovery attempts.
  * Simplified assertions and added short synchronization to ensure reliable timing in test verifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->