### PR TITLE
Retrieve environment name form the event properties

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -118,7 +118,7 @@ public class MoesifClient {
             return;
         }
         
-        String eventEnvironment = (String) properties.get(Constants.DEPLOYMENT_TYPE);
+        String eventEnvironment = (String) properties.get(Constants.ENVIRONMENT_NAME);
         if (eventEnvironment == null || eventEnvironment.isEmpty()) {
             log.warn("Event missing environment for organization: {}. Event will be skipped.", orgId);
             return;
@@ -128,11 +128,6 @@ public class MoesifClient {
         if (orgKeyMapping == null) {
             log.debug("No Moesif key found for organization: {}. Event will be skipped.", orgId);
             return;
-        }
-
-        if ("SANDBOX".equalsIgnoreCase(eventEnvironment)) {
-            log.debug("Mapping SANDBOX environment to Development for organization: {}", orgId);
-            eventEnvironment = "Development";
         }
 
         String moesifKey;

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -114,6 +114,6 @@ public class Constants {
     public static final String MOESIF_USER_AGENT_KEY = "User-Agent";
     public static final String GATEWAY_URL = "x-original-gw-url";
     public static final String DEPLOYMENT_TYPE = "deployment-type";
-     public static final String ENVIRONMENT_NAME = "api-environment-name";
+    public static final String ENVIRONMENT_NAME = "api-environment-name";
     public static final String PRODUCTION = "PRODUCTION";
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -114,5 +114,6 @@ public class Constants {
     public static final String MOESIF_USER_AGENT_KEY = "User-Agent";
     public static final String GATEWAY_URL = "x-original-gw-url";
     public static final String DEPLOYMENT_TYPE = "deployment-type";
+     public static final String ENVIRONMENT_NAME = "api-environment-name";
     public static final String PRODUCTION = "PRODUCTION";
 }


### PR DESCRIPTION
This pull request updates how the environment name is handled in the Moesif metrics publishing logic. The main change is to use a new property key for the environment name and to remove the special mapping of "SANDBOX" to "Development".

Key changes:

**Environment property handling:**
* Added a new constant `ENVIRONMENT_NAME` in `Constants.java` to represent the API environment name property.
* Updated `MoesifClient.java` to use `Constants.ENVIRONMENT_NAME` instead of `Constants.DEPLOYMENT_TYPE` when retrieving the event environment.

**Environment mapping logic:**
* Removed the logic that mapped the "SANDBOX" environment to "Development" in `MoesifClient.java`. Now, the environment name is used as-is.## Purpose