### PR TITLE
Moesif: handle error reponses properly

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/MoesifClient.java
@@ -209,8 +209,8 @@ public class MoesifClient extends AbstractMoesifClient {
                     .headers(rspHeaders)
                     .build();
 
-            if (userName.contains("@carbon.super")) {
-                modifiedUserName = userName.replace("@carbon.super", "");
+            if (userName.contains(Constants.CARBON_SUPER_SUFFIX)) {
+                modifiedUserName = userName.replace(Constants.CARBON_SUPER_SUFFIX, "");
             } else {
                 modifiedUserName = userName;
             }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -27,6 +27,7 @@ import com.moesif.api.models.EventRequestBuilder;
 import com.moesif.api.models.EventRequestModel;
 import com.moesif.api.models.EventResponseBuilder;
 import com.moesif.api.models.EventResponseModel;
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.am.analytics.publisher.reporter.moesif.util.MoesifMicroserviceConstants;
@@ -142,7 +143,7 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
                     dateTimeFormatter.parse((String) data.get(Constants.REQUEST_TIMESTAMP)));
 
             String verb = (String) data.get(Constants.API_METHOD);
-            if (verb == null || verb.isEmpty()) {
+            if (StringUtils.isEmpty(verb)) {
                 verb = Constants.NOT_APPLICABLE;
             }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -54,7 +54,6 @@ import java.util.Set;
 public class SimpleMoesifClient extends AbstractMoesifClient {
     private final MoesifAPIClient moesifAPIClient;
     private final APIController api;
-    private static final String CARBON_SUPER_SUFFIX = "@carbon.super";
 
     public SimpleMoesifClient(String key) {
         this.moesifAPIClient = new MoesifAPIClient(key);
@@ -380,9 +379,9 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             }
         }
 
-        if (sanitizedUserName.endsWith(CARBON_SUPER_SUFFIX)) {
+        if (sanitizedUserName.endsWith(Constants.CARBON_SUPER_SUFFIX)) {
             return sanitizedUserName.substring(0,
-                    sanitizedUserName.length() - CARBON_SUPER_SUFFIX.length());
+                    sanitizedUserName.length() - Constants.CARBON_SUPER_SUFFIX.length());
         }
 
         if (sanitizedUserName.isEmpty()) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -145,17 +145,16 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
                 verb = Constants.NOT_APPLICABLE;
             }
 
-            String uri = "";
+            String uri = Constants.NOT_APPLICABLE;
             String apiResourceTemplate = (String) data.get(Constants.API_RESOURCE_TEMPLATE);
             LinkedHashMap properties = (LinkedHashMap) data.get(Constants.PROPERTIES);
             String apiContext = (String) properties.get(Constants.API_CONTEXT);
             String gwURL = (String) properties.get(Constants.GATEWAY_URL);
-            uri = apiContext + apiResourceTemplate;
-            if (gwURL != null) {
+            if (gwURL != null && !gwURL.isEmpty()) {
                 uri = gwURL;
-            }
-            if (uri.isEmpty()) {
-                uri = Constants.NOT_APPLICABLE;
+            } else if (apiContext != null && !apiContext.isEmpty()
+                    && apiResourceTemplate != null && !apiResourceTemplate.isEmpty()) {
+                uri = apiContext + apiResourceTemplate;
             }
 
             eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(uri)

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -53,6 +53,7 @@ import java.util.Set;
 public class SimpleMoesifClient extends AbstractMoesifClient {
     private final MoesifAPIClient moesifAPIClient;
     private final APIController api;
+    private static final String CARBON_SUPER_SUFFIX = "@carbon.super";
 
     public SimpleMoesifClient(String key) {
         this.moesifAPIClient = new MoesifAPIClient(key);
@@ -378,8 +379,9 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             }
         }
 
-        if (sanitizedUserName.contains("@carbon.super")) {
-            return sanitizedUserName.replace("@carbon.super", "");
+        if (sanitizedUserName.endsWith(CARBON_SUPER_SUFFIX)) {
+            return sanitizedUserName.substring(0,
+                    sanitizedUserName.length() - CARBON_SUPER_SUFFIX.length());
         }
 
         if (sanitizedUserName.isEmpty()) {

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -108,9 +108,9 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
         Map<String, Object> metadata = new HashMap<>();
         populateMetadata(data, metadata);
 
+        modifiedUserName = sanitizeUserName(data);
         if (!data.containsKey(Constants.ERROR_CODE)) {
             final String userIP = (String) data.get(Constants.USER_IP);
-            final String userName = (String) data.get(Constants.USER_NAME);
             final String apiContext = (String) ((LinkedHashMap) data.get(Constants.PROPERTIES)).get(
                     Constants.API_CONTEXT);
             final String apiResourceTemplate = (String) data.get(Constants.API_RESOURCE_TEMPLATE);
@@ -135,22 +135,31 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             eventRsp = new EventResponseBuilder().time(Date.from(responseTimestamp))
                     .status((int) data.get(Constants.PROXY_RESPONSE_CODE)).headers(rspHeaders).build();
 
-            if (userName.contains("@carbon.super")) {
-                modifiedUserName = userName.replace("@carbon.super", "");
-            } else {
-                modifiedUserName = userName;
-            }
-
         } else {
-
-            modifiedUserName = (String) data.get(Constants.API_CREATION);
-
             DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
             Instant requestTimestamp = Instant.from(
                     dateTimeFormatter.parse((String) data.get(Constants.REQUEST_TIMESTAMP)));
 
-            eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(Constants.NOT_APPLICABLE)
-                    .verb(Constants.NOT_APPLICABLE).apiVersion((String) data.get(Constants.API_VERSION))
+            String verb = (String) data.get(Constants.API_METHOD);
+            if (verb == null || verb.isEmpty()) {
+                verb = Constants.NOT_APPLICABLE;
+            }
+
+            String uri = "";
+            String apiResourceTemplate = (String) data.get(Constants.API_RESOURCE_TEMPLATE);
+            LinkedHashMap properties = (LinkedHashMap) data.get(Constants.PROPERTIES);
+            String apiContext = (String) properties.get(Constants.API_CONTEXT);
+            String gwURL = (String) properties.get(Constants.GATEWAY_URL);
+            uri = apiContext + apiResourceTemplate;
+            if (gwURL != null) {
+                uri = gwURL;
+            }
+            if (uri.isEmpty()) {
+                uri = Constants.NOT_APPLICABLE;
+            }
+
+            eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(uri)
+                    .verb(verb).apiVersion((String) data.get(Constants.API_VERSION))
                     .headers(reqHeaders).build();
 
             Date dateNow = Date.from(Instant.now());
@@ -338,4 +347,48 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
         }
     }
 
+    /**
+     * Sanitizes the username by removing the @carbon.super suffix.
+     * Extracts username from data map or properties, then removes the @carbon.super suffix if present.
+     *
+     * @param data The data map containing user information.
+     * @return The sanitized username or `Constants.UNKNOWN_VALUE` if no username is found
+     */
+    private String sanitizeUserName(Map<String, Object> data) {
+        String sanitizedUserName = "";
+        String userName = (String) data.get(Constants.USER_NAME);
+        Object propertiesObj = data.get(Constants.PROPERTIES);
+
+        if (userName != null && !userName.isEmpty()) {
+            sanitizedUserName = userName;
+            if (log.isDebugEnabled()) {
+                log.debug("Using userName from data: {}", userName);
+            }
+        } else if (propertiesObj instanceof LinkedHashMap) {
+            // We've confirmed it's a LinkedHashMap, but we still need to
+            // suppress the warning for the *generic* part (<String, Object>),
+            // which `instanceof` cannot check.
+            @SuppressWarnings("unchecked")
+            LinkedHashMap<String, Object> properties = (LinkedHashMap<String, Object>) propertiesObj;
+            String propUserName = (String) properties.get(Constants.USER_NAME);
+            if (propUserName != null) {
+                sanitizedUserName = propUserName;
+                if (log.isDebugEnabled()) {
+                    log.debug("Using userName from properties: {}", propUserName);
+                }
+            }
+        }
+
+        if (sanitizedUserName.contains("@carbon.super")) {
+            return sanitizedUserName.replace("@carbon.super", "");
+        }
+
+        if (sanitizedUserName.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("No username found, returning UNKNOWN_VALUE");
+            }
+            return Constants.UNKNOWN_VALUE;
+        }
+        return sanitizedUserName;
+    }
 }

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -151,10 +151,10 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             LinkedHashMap properties = (LinkedHashMap) data.get(Constants.PROPERTIES);
             String apiContext = (String) properties.get(Constants.API_CONTEXT);
             String gwURL = (String) properties.get(Constants.GATEWAY_URL);
-            if (gwURL != null && !gwURL.isEmpty()) {
+            if (StringUtils.isNotEmpty(gwURL)) {
                 uri = gwURL;
-            } else if (apiContext != null && !apiContext.isEmpty()
-                    && apiResourceTemplate != null && !apiResourceTemplate.isEmpty()) {
+            } else if (StringUtils.isNotEmpty(apiContext) 
+                && StringUtils.isNotEmpty(apiResourceTemplate)) {
                 uri = apiContext + apiResourceTemplate;
             }
 

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -359,7 +359,7 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
         String userName = (String) data.get(Constants.USER_NAME);
         Object propertiesObj = data.get(Constants.PROPERTIES);
 
-        if (userName != null && !userName.isEmpty()) {
+        if (StringUtils.isNotEmpty(userName)) {
             sanitizedUserName = userName;
             if (log.isDebugEnabled()) {
                 log.debug("Using userName from data: {}", userName);

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/GenericInputValidator.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/reporter/GenericInputValidator.java
@@ -275,6 +275,8 @@ public class GenericInputValidator {
                     new AbstractMap.SimpleImmutableEntry<>(API_VERSION, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(API_CREATION, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(API_CREATOR_TENANT_DOMAIN, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_METHOD, String.class),
+                    new AbstractMap.SimpleImmutableEntry<>(API_RESOURCE_TEMPLATE, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(APPLICATION_ID, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(APPLICATION_NAME, String.class),
                     new AbstractMap.SimpleImmutableEntry<>(APPLICATION_OWNER, String.class),

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -145,4 +145,5 @@ public class Constants {
     public static final String REQUEST_HEADERS = "requestHeaders";
     public static final String RESPONSE_HEADERS = "responseHeaders";
 
+    public static final String CARBON_SUPER_SUFFIX = "@carbon.super";
 }


### PR DESCRIPTION
Related to: https://github.com/wso2/api-manager/issues/3968
This pull request introduces improvements to how usernames are sanitized and how request URIs and methods are constructed in the event publishing client. The main focus is on making username extraction and sanitization more robust, and on ensuring accurate event request data even when some fields are missing. Additionally, the input validator now expects more API-related fields.

**User and Request Data Handling Improvements:**

* Added the `sanitizeUserName` method to consistently extract and clean the username from either the main data map or its properties, removing the `@carbon.super` suffix if present and defaulting to `Constants.UNKNOWN_VALUE` if not found.
* Replaced inline username sanitization logic in `buildEventResponse` with a call to the new `sanitizeUserName` method, simplifying and centralizing username handling. [[1]](diffhunk://#diff-48560073cd72e7802031d05ff08a150eeeae332178d6e49436ee7a9e6969fef9R111-L113) [[2]](diffhunk://#diff-48560073cd72e7802031d05ff08a150eeeae332178d6e49436ee7a9e6969fef9L138-R162)

**Event Request Construction Enhancements:**

* Improved construction of the request URI and HTTP verb in `buildEventResponse` to handle missing or empty values gracefully, using fallback values when necessary.

**Input Validation Updates:**

* Updated `GenericInputValidator` to include `API_METHOD` and `API_RESOURCE_TEMPLATE` as required string fields, ensuring these are validated when present in event data.