### PR TITLE
Request/Response body support for Moesif analytics (publisher side)

### DIFF
--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/client/SimpleMoesifClient.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.am.analytics.publisher.client;
 
+import com.moesif.api.BodyParser;
 import com.moesif.api.MoesifAPIClient;
 import com.moesif.api.controllers.APIController;
 import com.moesif.api.http.client.APICallBack;
@@ -178,6 +179,20 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
 
         populateHeaders(data, reqHeaders, rspHeaders);
 
+        // Override the headers-map Content-Type with the captured body's real media type so Moesif can
+        // label/parse the body even when send_headers is off (populateHeaders otherwise defaults it to
+        // application/json). Done before resolveBody so BodyParser's JSON detection also sees the right
+        // type. Applied only when a body is actually present, so no-body events keep their headers.
+        applyBodyContentType(data, reqHeaders, Constants.REQUEST_BODY, Constants.REQUEST_CONTENT_TYPE);
+        applyBodyContentType(data, rspHeaders, Constants.RESPONSE_BODY, Constants.RESPONSE_CONTENT_TYPE);
+
+        // Resolve request/response bodies (and their transfer encodings) from properties, removing them
+        // so they are not also duplicated into metadata by populateAIInfo's metadata.putAll(properties).
+        BodyParser.BodyWrapper requestBody = resolveBody(data, reqHeaders,
+                Constants.REQUEST_BODY, Constants.REQUEST_BODY_TRANSFER_ENCODING);
+        BodyParser.BodyWrapper responseBody = resolveBody(data, rspHeaders,
+                Constants.RESPONSE_BODY, Constants.RESPONSE_BODY_TRANSFER_ENCODING);
+
         EventRequestModel eventReq;
         EventResponseModel eventRsp;
         EventModel eventModel = new EventModel();
@@ -208,10 +223,12 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
 
             eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(uri)
                     .verb((String) data.get(Constants.API_METHOD)).apiVersion((String) data.get(Constants.API_VERSION))
-                    .ipAddress(userIP).headers(reqHeaders).build();
+                    .ipAddress(userIP).headers(reqHeaders)
+                    .body(requestBody.body).transferEncoding(requestBody.transferEncoding).build();
 
             eventRsp = new EventResponseBuilder().time(Date.from(responseTimestamp))
-                    .status((int) data.get(Constants.PROXY_RESPONSE_CODE)).headers(rspHeaders).build();
+                    .status((int) data.get(Constants.PROXY_RESPONSE_CODE)).headers(rspHeaders)
+                    .body(responseBody.body).transferEncoding(responseBody.transferEncoding).build();
 
         } else {
             DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
@@ -237,12 +254,14 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
 
             eventReq = new EventRequestBuilder().time(Date.from(requestTimestamp)).uri(uri)
                     .verb(verb).apiVersion((String) data.get(Constants.API_VERSION))
-                    .headers(reqHeaders).build();
+                    .headers(reqHeaders)
+                    .body(requestBody.body).transferEncoding(requestBody.transferEncoding).build();
 
             Date dateNow = Date.from(Instant.now());
 
             eventRsp = new EventResponseBuilder().time(dateNow).status((int) data.get(Constants.PROXY_RESPONSE_CODE))
-                    .headers(rspHeaders).build();
+                    .headers(rspHeaders)
+                    .body(responseBody.body).transferEncoding(responseBody.transferEncoding).build();
         }
 
         eventModel.setRequest(eventReq);
@@ -382,6 +401,82 @@ public class SimpleMoesifClient extends AbstractMoesifClient {
             }
             metadata.putAll(properties);
         }
+    }
+
+    /**
+     * Removes and returns a body value ({@code requestBody}/{@code responseBody}) from the event's
+     * nested {@code properties} map. Removing it prevents the raw body from also being copied into
+     * Moesif metadata by {@link #populateAIInfo}.
+     *
+     * @param data the event data map
+     * @param key  the body property key
+     * @return the raw body value, or {@code null} if absent
+     */
+    private Object extractAndRemoveBody(Map<String, Object> data, String key) {
+        Object propertiesObj = data.get(Constants.PROPERTIES);
+        if (propertiesObj instanceof Map) {
+            return ((Map<String, Object>) propertiesObj).remove(key);
+        }
+        return null;
+    }
+
+    /**
+     * When a body is present in the event's {@code properties}, sets the given headers map's
+     * {@code Content-Type} to the captured body's media type (property {@code contentTypeKey}), so Moesif
+     * renders the body correctly regardless of {@code send_headers}. Only real media types (containing
+     * "/") override the default; the content-type property is left in {@code properties} as metadata.
+     *
+     * @param data           the event data map
+     * @param headers        the request/response headers map to update
+     * @param bodyKey        the body property key (presence gates the override)
+     * @param contentTypeKey the content-type property key
+     */
+    private void applyBodyContentType(Map<String, Object> data, Map<String, String> headers,
+                                      String bodyKey, String contentTypeKey) {
+        Object propertiesObj = data.get(Constants.PROPERTIES);
+        if (!(propertiesObj instanceof Map)) {
+            return;
+        }
+        Map<String, Object> properties = (Map<String, Object>) propertiesObj;
+        Object body = properties.get(bodyKey);
+        if (!(body instanceof String) || ((String) body).isEmpty()) {
+            return;
+        }
+        Object contentType = properties.get(contentTypeKey);
+        if (contentType instanceof String && ((String) contentType).contains("/")) {
+            headers.put(Constants.MOESIF_CONTENT_TYPE_KEY, ((String) contentType).trim());
+        }
+    }
+
+    /**
+     * Resolves a captured body into a Moesif {@link BodyParser.BodyWrapper} (body + transferEncoding),
+     * removing both the body and its transfer-encoding hint from the event's nested {@code properties}
+     * map so they are not also copied into Moesif metadata by {@link #populateAIInfo}.
+     *
+     * <p>Binary payloads are pre-encoded as Base64 by the gateway and passed through with
+     * {@code transferEncoding=base64}. JSON/text payloads are handed to Moesif's {@link BodyParser},
+     * which renders JSON as a structured object and Base64-encodes anything else (the Moesif standard).</p>
+     *
+     * @param data        the event data map
+     * @param headers     the request/response headers (used by BodyParser to detect JSON)
+     * @param bodyKey     the body property key
+     * @param encodingKey the transfer-encoding hint property key
+     * @return a body wrapper; {@code body}/{@code transferEncoding} are {@code null} when no body captured
+     */
+    private BodyParser.BodyWrapper resolveBody(Map<String, Object> data, Map<String, String> headers,
+                                               String bodyKey, String encodingKey) {
+        Object encoding = extractAndRemoveBody(data, encodingKey);
+        Object body = extractAndRemoveBody(data, bodyKey);
+        if (!(body instanceof String) || ((String) body).isEmpty()) {
+            return new BodyParser.BodyWrapper(null, null);
+        }
+        String bodyString = (String) body;
+        if (Constants.TRANSFER_ENCODING_BASE64.equals(encoding)) {
+            // Binary: already Base64-encoded by the gateway; pass through verbatim.
+            return new BodyParser.BodyWrapper(bodyString, Constants.TRANSFER_ENCODING_BASE64);
+        }
+        // JSON/text: Moesif standard - structured JSON object, otherwise Base64.
+        return BodyParser.parseBody(headers, bodyString);
     }
 
     /**

--- a/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
+++ b/component/publisher-client/src/main/java/org/wso2/am/analytics/publisher/util/Constants.java
@@ -144,6 +144,15 @@ public class Constants {
     public static final String MOESIF_BASE_URL = "moesif_base_url";
     public static final String REQUEST_HEADERS = "requestHeaders";
     public static final String RESPONSE_HEADERS = "responseHeaders";
+    public static final String REQUEST_BODY = "requestBody";
+    public static final String RESPONSE_BODY = "responseBody";
+    public static final String REQUEST_BODY_TRANSFER_ENCODING = "requestBodyTransferEncoding";
+    public static final String RESPONSE_BODY_TRANSFER_ENCODING = "responseBodyTransferEncoding";
+    public static final String TRANSFER_ENCODING_BASE64 = "base64";
+    // The captured body's Content-Type, sent by the gateway so a logged body can be labeled/parsed
+    // correctly by Moesif even when full header sending (send_headers) is disabled.
+    public static final String REQUEST_CONTENT_TYPE = "requestContentType";
+    public static final String RESPONSE_CONTENT_TYPE = "responseContentType";
 
     public static final String CARBON_SUPER_SUFFIX = "@carbon.super";
 }


### PR DESCRIPTION
## Purpose

- **Related issue:** https://github.com/wso2/api-manager/issues/5128
- **Companion PR (gateway capture side, `carbon-apimgt`):** https://github.com/wso2/carbon-apimgt/pull/13927

> This is one half of a **two-repo** change. The gateway (`carbon-apimgt`) captures the
> body into the analytics event `properties`; this PR maps those properties onto the
> Moesif SDK event.

### Problem
The WSO2 APIM Moesif plugin is not able to capture request and response body/payload data in Moesif.

### Root cause (publisher side)

`SimpleMoesifClient.buildEventResponse()` built the Moesif event with `.headers(...)` but never
called the SDK's `.body(...)` / `.transferEncoding(...)`. So even if a body were present in the
event `properties`, it was never sent to Moesif's body fields. (The gateway side never captured a
body in the first place, as addressed by the companion PR.)

### Intended outcome

When enabled, the request and response bodies reach Moesif in the form Moesif expects  (JSON as
structured objects and all other content types as Base64 with the correct `Content-Type`) without
disrupting the proxied call.

## Goals

### Functional goals

- Forward the captured request/response body to Moesif's Body panels via the SDK's
  `.body(...)` / `.transferEncoding(...)`.
- Render bodies the way Moesif expects: **JSON → structured object**, everything else → **Base64**
  with the correct `Content-Type`.
- Label/parse the body correctly **independent of `send_headers`**.
- Do not leak the raw body into Moesif **metadata**.

### Constraints & non-goals

- **Property-key contract:** the `properties` key strings must match the gateway
  (`carbon-apimgt`) exactly (see the table under *Approach*).
- No change to the upstream `AbstractMoesifClient.populateHeaders()` (which defaults `Content-Type`
  to `application/json`); the fix overrides that default only at the body-aware layer.
- The org/Choreo-mode `MoesifClient` is **out of scope**; the interactive `type=moesif` path uses
  `SimpleMoesifClient`.

## Approach

### Changes

| File | Change |
|------|--------|
| `client/SimpleMoesifClient.java` | Read the captured body from `properties`, set it on all four `EventRequest`/`EventResponse` builders (success + error branches), apply the correct `Content-Type`, and strip the body keys from `properties`. |
| `util/Constants.java` | New property-key constants matching the gateway exactly. |

New helper methods on `SimpleMoesifClient`:

| Method | Responsibility |
|--------|----------------|
| `resolveBody(...)` | Turn a captured body property into a Moesif `BodyParser.BodyWrapper` (`body` + `transferEncoding`). |
| `applyBodyContentType(...)` | Override the headers-map `Content-Type` with the body's real media type. |
| `extractAndRemoveBody(...)` | Remove the body/encoding keys from `properties` so they don't leak into Moesif metadata. |

### How it works

`buildEventResponse()`, right after `populateHeaders(...)`:

```java
// Correct the headers Content-Type from the captured body's media type (before resolveBody,
// so BodyParser's JSON detection sees the right type). Only when a body is actually present.
applyBodyContentType(data, reqHeaders, Constants.REQUEST_BODY, Constants.REQUEST_CONTENT_TYPE);
applyBodyContentType(data, rspHeaders, Constants.RESPONSE_BODY, Constants.RESPONSE_CONTENT_TYPE);

// Resolve bodies (and encodings) from properties, removing them so they aren't duplicated
// into metadata by populateAIInfo's metadata.putAll(properties).
BodyParser.BodyWrapper requestBody  = resolveBody(data, reqHeaders,
        Constants.REQUEST_BODY,  Constants.REQUEST_BODY_TRANSFER_ENCODING);
BodyParser.BodyWrapper responseBody = resolveBody(data, rspHeaders,
        Constants.RESPONSE_BODY, Constants.RESPONSE_BODY_TRANSFER_ENCODING);
```

…then each builder gains `.body(...).transferEncoding(...)`:

```java
eventReq = new EventRequestBuilder().time(...).uri(uri)
        .verb(...).apiVersion(...).ipAddress(userIP).headers(reqHeaders)
        .body(requestBody.body).transferEncoding(requestBody.transferEncoding).build();
```

`resolveBody(...)` — encoding decision:

```java
if (Constants.TRANSFER_ENCODING_BASE64.equals(encoding)) {
    // Binary: already Base64-encoded by the gateway; pass through verbatim.
    return new BodyParser.BodyWrapper(bodyString, Constants.TRANSFER_ENCODING_BASE64);
}
// JSON/text: Moesif standard — structured JSON object, otherwise Base64.
return BodyParser.parseBody(headers, bodyString);
```

### Design decisions

- **JSON → structured object, everything else → Base64** is Moesif's own `BodyParser` behavior
  (its only transfer encodings are `null` for structured JSON and `"base64"`). No plain-text mode
  exists; XML/SOAP/GraphQL/text/binary are rendered via Base64 + `Content-Type`.
- **`Content-Type` independent of `send_headers`.** Moesif chooses how to render a body from the
  `Content-Type` in the event headers, and `populateHeaders` defaults it to `application/json`.
  We override it with the body's real media type whenever a body is present, so a Base64
  binary/XML body is not mislabeled, regardless of whether full header logging is enabled.
- **No metadata leakage.** `resolveBody`/`extractAndRemoveBody` remove the body + encoding keys
  from `properties` so the raw body is not also copied into Moesif metadata by `populateAIInfo`'s
  `metadata.putAll(properties)`. (`requestContentType`/`responseContentType` are intentionally left
  as small, useful metadata.)